### PR TITLE
Implement timer count readback (Fix #25)

### DIFF
--- a/hw/arm/prusa/buddyboard.c
+++ b/hw/arm/prusa/buddyboard.c
@@ -103,7 +103,7 @@ static void buddy_init(MachineState *machine)
         static const uint8_t en_pins[4] = {3, 14, 2, 10};
         static const uint8_t diag_pins[4] = {2, 1, 3, 15};
         static const uint8_t diag_ports[4] = {GPIO_E, GPIO_E, GPIO_E, GPIO_A};
-        static const uint8_t is_inverted[4] = {1,1,0,0};
+        static const uint8_t is_inverted[4] = {1,1,0,1};
         static const int32_t ends[4] = { 100*16*182, 100*16*183, 400*16*185,0 };
         static const int32_t stepsize[4] = { 100*16, 100*16, 400*16, 320*16 };
 

--- a/hw/arm/prusa/parts/tmc2209.c
+++ b/hw/arm/prusa/parts/tmc2209.c
@@ -267,7 +267,7 @@ static void tmc2209_step(void *opaque, int n, int value) {
         s->current_step+=s->ms_increment;
 	}
     bool bStall = false;
-    if (1)//!cfg.bHasNoEndStops)
+    if (s->max_step != 0 )// If max_step ==0 it means endstopless, e.g. extruder.
     {
         if (s->current_step<0)
         {

--- a/hw/arm/prusa/stm32f407/stm32f2xx_tim.h
+++ b/hw/arm/prusa/stm32f407/stm32f2xx_tim.h
@@ -184,6 +184,7 @@ struct f2xx_tim {
     qemu_irq pwm_ratio_changed[4];
     qemu_irq pwm_enable[4], pwm_pin[4];
 
+    int64_t count_timebase;
 
     stm32_periph_t periph;
     Stm32Rcc *rcc; // RCC for clock speed. 

--- a/hw/arm/prusa/stm32f407/stm32f407_soc.c
+++ b/hw/arm/prusa/stm32f407/stm32f407_soc.c
@@ -475,7 +475,7 @@ static void stm32f407_soc_realize(DeviceState *dev_soc, Error **errp)
     // create_unimplemented_device("DMA2",        0x40026400, 0x400);
     create_unimplemented_device("Ethernet",    0x40028000, 0x1400);
     create_unimplemented_device("USB OTG HS",  0x40040000, 0x30000);
-    create_unimplemented_device("USB OTG FS",  0x50000000, 0x31000);
+    create_unimplemented_device("USB OTG FS",  0x50000000, 0x31000); // Note - FS is the serial port/micro-usb connector
     create_unimplemented_device("DCMI",        0x50050000, 0x400);
     create_unimplemented_device("RNG",         0x50060800, 0x400);
     create_unimplemented_device("OTP",         0x1FFF7800, 0x210);


### PR DESCRIPTION
### Description

Implements timer count readback

### Behaviour/ Breaking changes

May uncover more bugs from other areas that want to read the current timer count.

### Have you tested the changes?

Yes, simulator no longer freezes in the E ISR when loading filament.

### Linked issues:

 - Closes #25 
