### PR TITLE
General cleanup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
   # This workflow contains a single job called "build"
   cppcheck:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get purge clang-*
-        sudo apt-get -o Dir::Cache::Archives=`pwd`/packages install clang-5.0 clang-tidy
+        sudo apt-get -o Dir::Cache::Archives=`pwd`/packages install clang-6.0 clang-tidy
         sudo apt-get -o Dir::Cache::Archives=`pwd`/packages install libelf-dev iwyu cppcheck
 
     - name: Cache permissions

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,7 +41,7 @@ jobs:
       id: cache-pkgs
       with:
           path: "packages"
-          key: "pkgs-linting_1_0"
+          key: "pkgs-linting_1_1"
     - name: Setup cache dir
       if:  ${{ ! steps.cache-valgrind.outputs.cache-hit }}
       run: mkdir -p packages/partial
@@ -49,8 +49,6 @@ jobs:
     - name: Install packages
       run: |
         sudo apt-get update
-        sudo apt-get purge clang-*
-        sudo apt-get -o Dir::Cache::Archives=`pwd`/packages install clang-6.0 clang-tidy
         sudo apt-get -o Dir::Cache::Archives=`pwd`/packages install libelf-dev iwyu cppcheck
 
     - name: Cache permissions

--- a/hw/arm/prusa/meson.build
+++ b/hw/arm/prusa/meson.build
@@ -3,10 +3,10 @@ subdir('stm32f407')
 arm_ss.add(when: 'CONFIG_BUDDYBOARD', if_true: files(
         'prusa-mini.c',
         'parts/encoder_input.c',
-        'parts/buddy_visuals.c',
         'parts/fan.c',
         'parts/heater.c',
         'parts/irsensor.c',
+        'parts/mini_visuals.c',
         'parts/st7789v.c',
         'parts/thermistor.c',
         'parts/tmc2209.c',

--- a/hw/arm/prusa/meson.build
+++ b/hw/arm/prusa/meson.build
@@ -1,7 +1,7 @@
 subdir('stm32f407')
 
 arm_ss.add(when: 'CONFIG_BUDDYBOARD', if_true: files(
-        'buddyboard.c',
+        'prusa-mini.c',
         'parts/st7789v.c',
         'parts/tmc2209.c',
         'parts/buddy_input.c',

--- a/hw/arm/prusa/meson.build
+++ b/hw/arm/prusa/meson.build
@@ -2,20 +2,20 @@ subdir('stm32f407')
 
 arm_ss.add(when: 'CONFIG_BUDDYBOARD', if_true: files(
         'prusa-mini.c',
-        'parts/st7789v.c',
-        'parts/tmc2209.c',
-        'parts/buddy_input.c',
-        'parts/thermistor.c',
+        'parts/encoder_input.c',
         'parts/buddy_visuals.c',
         'parts/fan.c',
         'parts/heater.c',
         'parts/irsensor.c',
+        'parts/st7789v.c',
+        'parts/thermistor.c',
+        'parts/tmc2209.c',
         '3rdParty/shmemq404/shmemq.c',
-        'utility/p404scriptable.c',
-        'utility/ScriptHost.cpp',
-        'utility/IScriptable.cpp',
         'utility/ArgHelper.cpp',
-        'utility/p404_script_console.c'
+        'utility/IScriptable.cpp',
+        'utility/ScriptHost.cpp',
+        'utility/p404_script_console.c',
+        'utility/p404scriptable.c',
     ))
 # Required if using Message queue IPC
 c = meson.get_compiler('c')

--- a/hw/arm/prusa/prusa-mini.c
+++ b/hw/arm/prusa/prusa-mini.c
@@ -242,12 +242,11 @@ static void prusa_mini_init(MachineState *machine)
         qdev_connect_gpio_out_named(dev, "pwm-out", 0, qdev_get_gpio_in_named(vis,"indicator-analog",4+i));
     }
 
-    dev = qdev_new("buddy-input");
+    dev = qdev_new("encoder-input");
     sysbus_realize(SYS_BUS_DEVICE(dev), &error_fatal);
-    // dev_get_gpio_out_connector(dev,"buddy-enc-button",0);
-    qdev_connect_gpio_out_named(dev, "buddy-enc-button",0,  qdev_get_gpio_in(DEVICE(&SOC->gpio[GPIO_E]),12));
-    qdev_connect_gpio_out_named(dev, "buddy-enc-a",0,  qdev_get_gpio_in(DEVICE(&SOC->gpio[GPIO_E]),15));
-    qdev_connect_gpio_out_named(dev, "buddy-enc-b",0,  qdev_get_gpio_in(DEVICE(&SOC->gpio[GPIO_E]),13));
+    qdev_connect_gpio_out_named(dev, "encoder-button",0,  qdev_get_gpio_in(DEVICE(&SOC->gpio[GPIO_E]),12));
+    qdev_connect_gpio_out_named(dev, "encoder-a",0,  qdev_get_gpio_in(DEVICE(&SOC->gpio[GPIO_E]),15));
+    qdev_connect_gpio_out_named(dev, "encoder-b",0,  qdev_get_gpio_in(DEVICE(&SOC->gpio[GPIO_E]),13));
 
     // Needs to come last because it has the scripting engine setup.
     dev = qdev_new("p404-scriptcon");

--- a/hw/arm/prusa/prusa-mini.c
+++ b/hw/arm/prusa/prusa-mini.c
@@ -35,12 +35,9 @@
 #include "utility/ArgHelper.h"
 #include "sysemu/runstate.h"
 
-
-
-
 #define BOOTLOADER_IMAGE "bootloader.bin"
 
-static void buddy_init(MachineState *machine)
+static void prusa_mini_init(MachineState *machine)
 {
     DeviceState *dev;
 
@@ -266,9 +263,26 @@ static void buddy_init(MachineState *machine)
 };
 
 
+static void prusa_mini_machine_init(MachineClass *mc)
+{
+    mc->desc = "Prusa Mini Board";
+    mc->init = prusa_mini_init;
+}
+
+DEFINE_MACHINE("prusa-mini", prusa_mini_machine_init)
+
+
+// TODO - remove this at some point in the future...
+
+static void buddy_init(MachineState *machine)
+{
+    error_setg(&error_fatal, "-machine prusabuddy has been deprecated. Please use -machine prusa-mini instead.\n");
+};
+
+
 static void buddy_machine_init(MachineClass *mc)
 {
-    mc->desc = "Prusa Buddy Board";
+    mc->desc = "Prusa Mini Board (Deprecated)";
     mc->init = buddy_init;
 }
 

--- a/hw/arm/prusa/prusa-mini.c
+++ b/hw/arm/prusa/prusa-mini.c
@@ -141,7 +141,7 @@ static void prusa_mini_init(MachineState *machine)
         qdev_realize(dev, bus, &error_fatal);
     }
 
-    DeviceState *vis = qdev_new("buddy-visuals");
+    DeviceState *vis = qdev_new("mini-visuals");
     sysbus_realize(SYS_BUS_DEVICE(vis), &error_fatal);
    
     {

--- a/hw/arm/prusa/stm32f407/stm32f407_soc.c
+++ b/hw/arm/prusa/stm32f407/stm32f407_soc.c
@@ -158,7 +158,7 @@ static void stm32f407_soc_initfn(Object *obj)
 
     object_initialize_child(obj, "iwdg",&s->iwdg, TYPE_STM32F4XX_IWDG);
 
-    // // object_initialize_child(obj, "otg_fs", &s->otg_fs, TYPE_DWC2_USB);
+    object_initialize_child(obj, "otg_fs", &s->otg_fs, TYPE_STM32F4xx_USB);
     // // object_property_add_const_link(OBJECT(&s->otg_fs), "dma-mr",
     // //                             OBJECT(&s->temp_usb));
     object_initialize_child(obj, "otg_hs", &s->otg_hs, TYPE_STM32F4xx_USB);
@@ -473,12 +473,12 @@ static void stm32f407_soc_realize(DeviceState *dev_soc, Error **errp)
     sysbus_mmio_map(busdev, 0, 0xE0000000UL);
 
     // IRQs: FS wakeup: 42 FS Global: 67
-    // if (!sysbus_realize(SYS_BUS_DEVICE(&s->otg_fs),errp))
-    // {
-    //     return;
-    // }    
-    // memory_region_add_subregion(system_memory, 0x50000000UL,
-    //     sysbus_mmio_get_region(SYS_BUS_DEVICE(&s->otg_fs), 0));
+    if (!sysbus_realize(SYS_BUS_DEVICE(&s->otg_fs),errp))
+    {
+        return;
+    }    
+    memory_region_add_subregion(system_memory, 0x50000000UL,
+        sysbus_mmio_get_region(SYS_BUS_DEVICE(&s->otg_fs), 0));
 
 
     // USB IRQs:


### PR DESCRIPTION
### Description

Misc cleanup (rename a few items to "mini" or generic equivalents where appropriate)

Fix/stub out USBFS in prep for 4.3.2 HAL change.

### Behaviour/ Breaking changes

 - USB_FS still not implemented, but now it at least looks like there is a device there to the firmware.
 - Deprecated `-machine prusabuddy` and replaced it with `-machine prusa-mini`

### Linked issues:

 - Partial for #13 
 - Contains fix for #55
