### PR TITLE
Fix #58 - hang if booting with USB connected.

### DIFF
--- a/hw/arm/prusa/stm32f407/stm32f2xx_rcc.h
+++ b/hw/arm/prusa/stm32f407/stm32f2xx_rcc.h
@@ -90,4 +90,6 @@ typedef struct Stm32f2xxRcc {
     uint16_t
     RCC_PLLI2SCFGR_PLLN;
 
+    qemu_irq reset[STM32_PERIPH_COUNT];
+
 } Stm32f2xxRcc;

--- a/hw/arm/prusa/stm32f407/stm32f407_soc.c
+++ b/hw/arm/prusa/stm32f407/stm32f407_soc.c
@@ -179,7 +179,7 @@ static void stm32f407_soc_realize(DeviceState *dev_soc, Error **errp)
 {
     STM32F407State *s = STM32F407_SOC(dev_soc);
     MemoryRegion *system_memory = get_system_memory();
-    DeviceState *dev, *armv7m;
+    DeviceState *dev, *armv7m, *rcc;
     SysBusDevice *busdev;
     Error *err = NULL;
     int i;
@@ -234,14 +234,14 @@ static void stm32f407_soc_realize(DeviceState *dev_soc, Error **errp)
     uint32_t osc_freq = 12000000; /*osc_freq*/
                    //osc32_freq = 32768; /*osc2_freq*/
 
-    dev = DEVICE(&(s->rcc));
-    qdev_prop_set_uint32(dev, "osc_freq", osc_freq);
+    rcc = DEVICE(&(s->rcc));
+    qdev_prop_set_uint32(rcc, "osc_freq", osc_freq);
     //qdev_prop_set_uint32(dev, "osc32_freq", osc32_freq);
     
-    if (!sysbus_realize(SYS_BUS_DEVICE(dev), errp)) {
+    if (!sysbus_realize(SYS_BUS_DEVICE(rcc), errp)) {
         return;
     }
-    busdev = SYS_BUS_DEVICE(dev);
+    busdev = SYS_BUS_DEVICE(rcc);
     sysbus_mmio_map(busdev, 0, 0x40023800);
     sysbus_connect_irq(busdev, 0, qdev_get_gpio_in(armv7m, STM32_RCC_IRQ));
 
@@ -489,6 +489,7 @@ static void stm32f407_soc_realize(DeviceState *dev_soc, Error **errp)
     }    
     sysbus_mmio_map(SYS_BUS_DEVICE(&s->otg_hs),0,0x40040000UL);
     sysbus_connect_irq(SYS_BUS_DEVICE(&s->otg_hs), 0, qdev_get_gpio_in(armv7m, 77));
+    qdev_connect_gpio_out_named(rcc,"reset",STM32_USB,qdev_get_gpio_in_named(DEVICE(&s->otg_hs),"rcc-reset",0));
 
 
     qemu_check_nic_model(&nd_table[0], "stm32f4xx-ethernet");

--- a/hw/arm/prusa/stm32f407/stm32f4xx_usb.c
+++ b/hw/arm/prusa/stm32f407/stm32f4xx_usb.c
@@ -1558,6 +1558,16 @@ static void STM32F4xx_reset_exit(Object *obj)
     }
 }
 
+static void stm32f4xx_usb_reset(void *opaque, int n, int level) {
+    // printf("RCC USB reset signal: %d\n",level);
+    STM32F4xxUSBState *s = STM32F4xx_USB(opaque);
+    if (level) {
+        STM32F4xx_reset_enter(OBJECT(s),RESET_TYPE_COLD);
+    } else {
+        STM32F4xx_reset_exit(OBJECT(s));
+    }
+}
+
 static void STM32F4xx_realize(DeviceState *dev, Error **errp)
 {
     SysBusDevice *sbd = SYS_BUS_DEVICE(dev);
@@ -1590,6 +1600,8 @@ static void STM32F4xx_realize(DeviceState *dev, Error **errp)
     s->eof_timer = timer_new_ns(QEMU_CLOCK_VIRTUAL, STM32F4xx_frame_boundary, s);
     s->frame_timer = timer_new_ns(QEMU_CLOCK_VIRTUAL, STM32F4xx_work_timer, s);
     s->async_bh = qemu_bh_new(STM32F4xx_work_bh, s);
+
+    qdev_init_gpio_in_named(dev,stm32f4xx_usb_reset,"rcc-reset",1);
 
     sysbus_init_irq(sbd, &s->irq);
 }


### PR DESCRIPTION
### Description

Fixes a bug where the boot would hang if a USB drive was connected at boot 

### Behaviour/ Breaking changes

None

### Have you tested the changes?

Yes, locally it fixes the issue described

### Linked issues:

 - Fixes #58 
