### PR TITLE
Savestates, clean up UART and RCC

### DIFF
--- a/hw/arm/prusa/parts/fan.c
+++ b/hw/arm/prusa/parts/fan.c
@@ -26,6 +26,7 @@
 #include "qemu/timer.h"
 #include "hw/irq.h"
 #include "hw/qdev-properties.h"
+#include "migration/vmstate.h"
 #include "../utility/macros.h"
 #include "../utility/p404scriptable.h"
 #include "../utility/ScriptHost_C.h"
@@ -197,12 +198,35 @@ static Property fan_properties[] = {
     DEFINE_PROP_END_OF_LIST()
 };
 
+static const VMStateDescription vmstate_fan = {
+    .name = TYPE_FAN,
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .fields      = (VMStateField []) {
+        VMSTATE_BOOL(pulse_state,fan_state),
+        VMSTATE_BOOL(is_nonlinear,fan_state),
+        VMSTATE_BOOL(is_stalled,fan_state),
+        VMSTATE_UINT8(pwm,fan_state),
+        VMSTATE_UINT8(label,fan_state),
+        VMSTATE_UINT32(max_rpm,fan_state),
+        VMSTATE_UINT32(current_rpm,fan_state),
+        VMSTATE_UINT32(usec_per_pulse,fan_state),
+        VMSTATE_INT32(last_level,fan_state),
+        VMSTATE_INT64(tOn,fan_state),
+        VMSTATE_INT64(tOff,fan_state),
+        VMSTATE_INT64(tLastOn,fan_state),
+        VMSTATE_TIMER_PTR(tach,fan_state),
+        VMSTATE_TIMER_PTR(softpwm,fan_state),
+        VMSTATE_END_OF_LIST(),
+    }
+};
+
 
 static void fan_class_init(ObjectClass *klass, void *data)
 {
     DeviceClass *dc = DEVICE_CLASS(klass);
     device_class_set_props(dc, fan_properties);
-
+    dc->vmsd = &vmstate_fan;
     P404ScriptIFClass *sc = P404_SCRIPTABLE_CLASS(klass);
     sc->ScriptHandler = fan_process_action;
 }

--- a/hw/arm/prusa/parts/irsensor.c
+++ b/hw/arm/prusa/parts/irsensor.c
@@ -86,8 +86,6 @@ static int irsensor_process_action(P404ScriptIF *obj, unsigned int action, scrip
     return ScriptLS_Finished;
 }
 
-
-
 static void irsensor_init(Object *obj)
 {
     IRState *s = IRSENSOR(obj);
@@ -102,10 +100,21 @@ static void irsensor_init(Object *obj)
     scripthost_register_scriptable(pScript);
 }
 
+static const VMStateDescription vmstate_irsensor = {
+    .name = TYPE_IRSENSOR,
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .fields      = (VMStateField []) {
+        VMSTATE_BOOL(state, IRState),
+        VMSTATE_END_OF_LIST(),
+    }
+};
+
 static void irsensor_class_init(ObjectClass *oc, void *data)
 {
     DeviceClass *dc = DEVICE_CLASS(oc);
     dc->reset = irsensor_reset;
+    dc->vmsd = &vmstate_irsensor;
     P404ScriptIFClass *sc = P404_SCRIPTABLE_CLASS(oc);
     sc->ScriptHandler = irsensor_process_action;
 }

--- a/hw/arm/prusa/parts/mini_visuals.c
+++ b/hw/arm/prusa/parts/mini_visuals.c
@@ -49,8 +49,6 @@ struct mini_visuals_state {
     shmemq_t *queue;
 #endif
     bool is_opened;
-
-    int32_t redraw;
     QEMUTimer *timer_flush;
 
 };

--- a/hw/arm/prusa/parts/thermistor.c
+++ b/hw/arm/prusa/parts/thermistor.c
@@ -196,7 +196,7 @@ static int thermistor_post_load(void *opaque, int version_id)
     ThermistorState *s = THERMISTOR(opaque);
 
     thermistor_set_table(s);
-    if (s->table_length == 0 || s->table == NULL) {
+    if (s->table_index >0 && (s->table_length == 0 || s->table == NULL)) {
         return -EINVAL;
     }
 

--- a/hw/arm/prusa/parts/thermistor.c
+++ b/hw/arm/prusa/parts/thermistor.c
@@ -25,6 +25,7 @@
 #include "hw/sysbus.h"
 #include "hw/qdev-properties.h"
 #include "thermistortables.h"
+#include "migration/vmstate.h"
 #include "../utility/macros.h"
 #include "../utility/p404scriptable.h"
 #include "../utility/ScriptHost_C.h"
@@ -45,6 +46,9 @@ struct ThermistorState {
     bool use_custom;
     int8_t oversampling;
     uint16_t start_temp;
+
+    // Saving state - because there's no VMSTATE_FLOAT
+    int32_t temp_256x,custom_256x;
 };
 
 enum {
@@ -121,10 +125,7 @@ static int thermistor_process_action(P404ScriptIF *obj, unsigned int action, scr
     return ScriptLS_Finished;
 }
 
-static void thermistor_reset(DeviceState *dev)
-{
-    ThermistorState *s = THERMISTOR(dev);
-    s->temperature = s->start_temp;
+static void thermistor_set_table(ThermistorState *s) {
     switch (s->table_index)
     {
         case 1:
@@ -141,10 +142,16 @@ static void thermistor_reset(DeviceState *dev)
             break;
         default:
             s->table = NULL;
-    s->table_length = 0;
+            s->table_length = 0;
             break;
     }
+}
 
+static void thermistor_reset(DeviceState *dev)
+{
+    ThermistorState *s = THERMISTOR(dev);
+    s->temperature = s->start_temp;
+    thermistor_set_table(s);
 }
 
 OBJECT_DEFINE_TYPE_SIMPLE_WITH_INTERFACES(ThermistorState, thermistor, THERMISTOR, SYS_BUS_DEVICE, {TYPE_P404_SCRIPTABLE}, {NULL});
@@ -184,11 +191,50 @@ static Property thermistor_properties[] = {
 };
 
 
+static int thermistor_post_load(void *opaque, int version_id)
+{
+    ThermistorState *s = THERMISTOR(opaque);
+
+    thermistor_set_table(s);
+    if (s->table_length == 0 || s->table == NULL) {
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+static int thermistor_pre_save(void *opaque)
+{
+    ThermistorState *s = THERMISTOR(opaque);
+
+    s->temp_256x = (s->temperature*256.f);
+    s->custom_256x = (s->custom_temp*256.f);
+    return 0;
+}
+
+static const VMStateDescription vmstate_thermistor = {
+    .name = TYPE_THERMISTOR,
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .post_load = thermistor_post_load,
+    .pre_save = thermistor_pre_save,
+    .fields      = (VMStateField []) {
+        VMSTATE_UINT16(table_index,ThermistorState),
+        VMSTATE_INT32(temp_256x,ThermistorState),
+        VMSTATE_INT32(custom_256x,ThermistorState),
+        VMSTATE_BOOL(use_custom,ThermistorState),
+        VMSTATE_INT8(oversampling,ThermistorState),
+        VMSTATE_UINT16(start_temp,ThermistorState),
+        VMSTATE_END_OF_LIST(),
+    }
+};
+
 static void thermistor_class_init(ObjectClass *klass, void *data)
 {
     DeviceClass *dc = DEVICE_CLASS(klass);
 
     dc->reset = thermistor_reset;
+    dc->vmsd = &vmstate_thermistor;
     device_class_set_props(dc, thermistor_properties);
 
     P404ScriptIFClass *sc = P404_SCRIPTABLE_CLASS(klass);

--- a/hw/arm/prusa/parts/thermistor.c
+++ b/hw/arm/prusa/parts/thermistor.c
@@ -38,6 +38,7 @@ struct ThermistorState {
 
     qemu_irq irq_value;
 
+    uint8_t index;
     uint16_t table_index;
     const short int *table;    
     int table_length;
@@ -187,6 +188,7 @@ static void thermistor_init(Object *obj)
 static Property thermistor_properties[] = {
     DEFINE_PROP_UINT16("temp", ThermistorState, start_temp,0),
     DEFINE_PROP_UINT16("table_no", ThermistorState, table_index, 0),
+    DEFINE_PROP_UINT8("index", ThermistorState, index, 0),
     DEFINE_PROP_END_OF_LIST(),
 };
 

--- a/hw/arm/prusa/prusa-mini.c
+++ b/hw/arm/prusa/prusa-mini.c
@@ -197,6 +197,7 @@ static void prusa_mini_init(MachineState *machine)
         if (i==1) bed = dev;
         qdev_prop_set_uint16(dev, "temp",startvals[i]);
         qdev_prop_set_uint16(dev, "table_no", tables[i]);
+        qdev_prop_set_uint8(dev, "index", i);
         sysbus_realize(SYS_BUS_DEVICE(dev), &error_fatal);
         qdev_connect_gpio_out_named(DEVICE(&SOC->adc[0]),"adc_read", channels[i],  qdev_get_gpio_in_named(dev, "thermistor_read_request",0));
         qdev_connect_gpio_out_named(dev, "thermistor_value",0, qdev_get_gpio_in_named(DEVICE(&SOC->adc[0]),"adc_data_in",channels[i]));

--- a/hw/arm/prusa/stm32f407/stm32_clk_type.h
+++ b/hw/arm/prusa/stm32f407/stm32_clk_type.h
@@ -1,0 +1,62 @@
+/*
+ * Basic Clock Tree Building Blocks
+ *
+ * Copyright (C) 2012 Andre Beckus
+ * Adapted for QEMU 5.2 in 2021 by VintagePC <http://github.com/vintagepc>
+ *
+ * Source code roughly based on omap_clk.c
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef STM32_CLK_H
+#define STM32_CLK_H
+
+#include "qemu/osdep.h"
+
+// Cannot be >255 as counts are stored in uint8_ts
+#define CLKTREE_MAX_IRQ 16
+#define CLKTREE_MAX_OUTPUT 24
+#define CLKTREE_MAX_INPUT 24
+
+static_assert(CLKTREE_MAX_INPUT<256,"DEFINE EXCEEDS SIZE OF uint8_t used to store it in struct Clk");
+static_assert(CLKTREE_MAX_OUTPUT<256, "DEFINE EXCEEDS SIZE OF uint8_t used to store it in struct Clk");
+static_assert(CLKTREE_MAX_IRQ<256, "DEFINE EXCEEDS SIZE OF uint8_t used to store it in struct Clk");
+
+
+struct Clk {                                                                    
+    const char *name;                                                           
+                                                                                
+    bool is_initialized;
+    bool enabled;                                                               
+                                                                                
+    uint32_t input_freq, output_freq, max_output_freq;                          
+                                                                                
+    uint16_t multiplier, divisor;                                               
+                                                                                
+    uint8_t user_count;                                                        
+    qemu_irq user[CLKTREE_MAX_IRQ]; /* Who to notify on change */               
+                                                                                
+    uint8_t output_count;                                                      
+    struct Clk *output[CLKTREE_MAX_OUTPUT];                                     
+                                                                                
+    uint8_t input_count;                                                       
+    int16_t selected_input;                                                         
+    struct Clk *input[CLKTREE_MAX_INPUT];                                       
+
+};                                                                              
+
+typedef struct Clk Clk_t;
+
+#endif // STM32_CLK_H

--- a/hw/arm/prusa/stm32f407/stm32_clktree.h
+++ b/hw/arm/prusa/stm32f407/stm32_clktree.h
@@ -25,9 +25,6 @@
 
 #include "qemu-common.h"
 
-#define CLKTREE_MAX_IRQ 16
-#define CLKTREE_MAX_OUTPUT 24
-#define CLKTREE_MAX_INPUT 24
 
 /* Use this when calling clktree_create_clk and clktree_set_selected_input */
 #define CLKTREE_NO_INPUT -1
@@ -35,23 +32,23 @@
 /* Use this when calling clktree_create_clk */
 #define CLKTREE_NO_MAX_FREQ UINT32_MAX
 
-typedef struct Clk *Clk;
+typedef struct Clk* Clk_p;
 
 /* Check if the clock output is enabled. */
-bool clktree_is_enabled(Clk clk);
+bool clktree_is_enabled(Clk_p clk);
 
 /* Get the clock's output frequency.  This will be 0 if:
  * - No clock is selected as an input.
  * - The clock output is not enabled.
  * - The multiplier is set to 0.
  */
-uint32_t clktree_get_output_freq(Clk clk);
+uint32_t clktree_get_output_freq(Clk_p clk);
 
 /* Add an IRQ to receive notifications when the clock frequency is updated. */
-void clktree_adduser(Clk clk, qemu_irq user);
+void clktree_adduser(Clk_p clk, qemu_irq user);
 
 /* Create a source clock (e.g. oscillator) with the given frequency. */
-Clk clktree_create_src_clk(
+void clktree_create_src_clk(Clk_p var,
                     const char *name,
                     uint32_t src_freq,
                     bool enabled);
@@ -59,7 +56,7 @@ Clk clktree_create_src_clk(
 /* Create a clock.  The vararg parameter specifies all of the source clocks
  * (use NULL to indicate the end of the list).  A warning will be generated if
  * the output frequency of the clock ever exceeds max_output_freq. */
-Clk clktree_create_clk(
+void clktree_create_clk( Clk_p var,
                     const char *name,
                     uint16_t multiplier,
                     uint16_t divisor,
@@ -69,15 +66,15 @@ Clk clktree_create_clk(
                     ...);
 
 /* Set the multiplier and divider scales. */
-void clktree_set_scale(Clk clk, uint16_t multiplier, uint16_t divisor);
+void clktree_set_scale(Clk_p clk, uint16_t multiplier, uint16_t divisor);
 
 /* Enable or disable the clock output. */
-void clktree_set_enabled(Clk clk, bool enabled);
+void clktree_set_enabled(Clk_p clk, bool enabled);
 
 /* Selects the specified input clock.  selected_input should be 0 to select the
  * first input clock passed in to clktree_create_clk, 1 for the second input
  * clock, and so on.  Pass in CLKTREE_NO_INPUT to not select any input
  * (i.e. input frequency will be 0). */
-void clktree_set_selected_input(Clk clk, int selected_input);
+void clktree_set_selected_input(Clk_p clk, int selected_input);
 
 #endif /* STM32_CLKTREE_H */

--- a/hw/arm/prusa/stm32f407/stm32_rcc.c
+++ b/hw/arm/prusa/stm32f407/stm32_rcc.c
@@ -3,9 +3,9 @@
 
 void stm32_rcc_check_periph_clk(Stm32Rcc *s, stm32_periph_t periph)
 {
-    Clk clk = s->PERIPHCLK[periph];
+    Clk_p clk = &s->PERIPHCLK[periph];
 
-    assert(clk != NULL);
+    assert(clk->is_initialized);
 
     if(!clktree_is_enabled(clk)) {
         /* I assume writing to a peripheral register while the peripheral clock
@@ -22,9 +22,9 @@ void stm32_rcc_set_periph_clk_irq(
         stm32_periph_t periph,
         qemu_irq periph_irq)
 {
-    Clk clk = s->PERIPHCLK[periph];
+    Clk_p clk = &s->PERIPHCLK[periph];
 
-    assert(clk != NULL);
+    assert(clk->is_initialized);
 
     clktree_adduser(clk, periph_irq);
 }
@@ -33,13 +33,9 @@ uint32_t stm32_rcc_get_periph_freq(
         Stm32Rcc *s,
         stm32_periph_t periph)
 {
-    Clk clk;
+    Clk_p clk = &s->PERIPHCLK[periph];
 
-    clk = s->PERIPHCLK[periph];
-
-    assert(clk != NULL);
+    assert(clk->is_initialized);
 
     return clktree_get_output_freq(clk);
 }
-
-

--- a/hw/arm/prusa/stm32f407/stm32_rcc.h
+++ b/hw/arm/prusa/stm32f407/stm32_rcc.h
@@ -3,7 +3,7 @@
 #include "stm32.h"
 #include "hw/arm/armv7m.h"
 #include "stm32_clktree.h"
-
+#include "stm32_clk_type.h"
 
 #define STM32_RCC_COMMON \
     SysBusDevice busdev; \
@@ -17,9 +17,13 @@
     qemu_irq irq; \
  \
     /* Peripheral clocks */ \
-    Clk PERIPHCLK[STM32_PERIPH_COUNT]; \
+    Clk_t PERIPHCLK[STM32_PERIPH_COUNT]; \
 
 /** RCC Base data structure */
+// NOTE: the Clk entries cannot be pointers that are malloc'd like they originally were
+// as this prevents you from being (easily) able to pass them through to the VMSTATE
+// vmsd and take advantage of save states. Ergo, the array is fixed (no malloc) and every
+// other area takes Clk_p pointers to a clock instead. 
 struct Stm32Rcc {
     STM32_RCC_COMMON
 };

--- a/hw/arm/prusa/stm32f407/stm32_uart.c
+++ b/hw/arm/prusa/stm32f407/stm32_uart.c
@@ -434,7 +434,7 @@ static void stm32_uart_write(void *opaque, hwaddr addr,
     Stm32Uart *s = (Stm32Uart *)opaque;
     int offset = addr & 0x3;
     uint32_t data = 0;
-    DPRINTF("%s: addr: 0x%llx, data: 0x%lx, size: %u\n", __func__, addr, data, size);
+    DPRINTF("%s: addr: 0x%llx, data: 0x%x, size: %u\n", __func__, addr, data, size);
 
     addr >>= 2;
     if (addr >= USART_R_END) {

--- a/hw/arm/prusa/stm32f407/stm32_uart.c
+++ b/hw/arm/prusa/stm32f407/stm32_uart.c
@@ -22,17 +22,21 @@
  */
 
 #include "qemu/osdep.h"
+#include "qemu-common.h"
 #include "hw/sysbus.h"
 #include "hw/irq.h"
 #include "exec/memory.h"
 #include "qemu/timer.h"
 #include "qemu/log.h"
+#include "migration/vmstate.h"
 #include "chardev/char-fe.h"
 #include "chardev/char.h"
 #include "stm32.h"
 #include "hw/qdev-properties.h"
 #include "stm32_uart.h"
 #include "qemu/bitops.h"
+#include "assert.h"
+#include "../utility/macros.h"
 
 
 
@@ -50,37 +54,14 @@
 #define DPRINTF(fmt, ...)
 #endif
 
-#define USART_SR_OFFSET 0x00
-#define USART_SR_TXE_BIT 7
-#define USART_SR_TC_BIT 6
-#define USART_SR_RXNE_BIT 5
-#define USART_SR_ORE_BIT 3
-
-#define USART_DR_OFFSET 0x04
-
-#define USART_BRR_OFFSET 0x08
-
-#define USART_CR1_OFFSET 0x0c
-#define USART_CR1_UE_BIT 13
-#define USART_CR1_M_BIT 12
-#define USART_CR1_PCE_BIT 10
-#define USART_CR1_PS_BIT 9
-#define USART_CR1_TXEIE_BIT 7
-#define USART_CR1_TCIE_BIT 6
-#define USART_CR1_RXNEIE_BIT 5
-#define USART_CR1_TE_BIT 3
-#define USART_CR1_RE_BIT 2
-
-#define USART_CR2_OFFSET 0x10
-#define USART_CR2_STOP_START 12
-#define USART_CR2_STOP_MASK 0x00003000
-
-#define USART_CR3_OFFSET 0x14
-#define USART_CR3_CTSE_BIT 9
-#define USART_CR3_RTSE_BIT 8
-#define USART_CR3_DMAR_BIT 6
-
-#define USART_GTPR_OFFSET 0x18
+#define USART_SR_OFFSET     0x00/4
+#define USART_DR_OFFSET     0x04/4 
+#define USART_BRR_OFFSET    0x08/4
+#define USART_CR1_OFFSET    0x0c/4
+#define USART_CR2_OFFSET    0x10/4
+#define USART_CR3_OFFSET    0x14/4
+#define USART_GTPR_OFFSET   0x18/4
+#define USART_R_END         0x1c/4
 
 /* HELPER FUNCTIONS */
 
@@ -93,10 +74,10 @@ static void stm32_uart_baud_update(Stm32Uart *s)
 
     uint64_t ns_per_bit;
 
-    if((s->USART_BRR == 0) || (clk_freq == 0)) {
+    if((s->regs[USART_BRR_OFFSET] == 0) || (clk_freq == 0)) {
         s->bits_per_sec = 0;
     } else {
-        s->bits_per_sec = clk_freq / s->USART_BRR;
+        s->bits_per_sec = clk_freq / s->regs[USART_BRR_OFFSET];
         ns_per_bit = 1000000000LL / s->bits_per_sec;
 
         /* We assume 10 bits per character.  This may not be exactly
@@ -137,10 +118,10 @@ static void stm32_uart_clk_irq_handler(void *opaque, int n, int level)
 static void stm32_uart_update_irq(Stm32Uart *s) {
     /* Note that we are not checking the ORE flag, but we should be. */
     int new_irq_level =
-       (s->USART_CR1_TCIE & s->USART_SR_TC) |
-       (s->USART_CR1_TXEIE & s->USART_SR_TXE) |
-       (s->USART_CR1_RXNEIE &
-               (s->USART_SR_ORE | s->USART_SR_RXNE));
+       (s->defs.CR1.TCIE & s->defs.SR.TC) |
+       (s->defs.CR1.TXEIE & s->defs.SR.TXE) |
+       (s->defs.CR1.RXNEIE &
+               (s->defs.SR.ORE | s->defs.SR.RXNE));
 
     /* Only trigger an interrupt if the IRQ level changes.  We probably could
      * set the level regardless, but we will just check for good measure.
@@ -149,7 +130,7 @@ static void stm32_uart_update_irq(Stm32Uart *s) {
         qemu_set_irq(s->irq, new_irq_level);
         s->curr_irq_level = new_irq_level;
     }
-    int new_dmar = s->USART_SR_RXNE && (s->USART_CR3 & (1<<USART_CR3_DMAR_BIT));
+    int new_dmar = s->defs.SR.RXNE && (s->defs.CR3.DMAR);
     if (new_dmar != s->dmar_current_level || new_dmar==1)
     {
         s->dmar_current_level = new_dmar;
@@ -167,26 +148,16 @@ static void stm32_uart_receive(void *opaque, const uint8_t *buf, int size);
 /* Routine to be called when a transmit is complete. */
 static void stm32_uart_tx_complete(Stm32Uart *s)
 {
-    if(s->USART_SR_TXE == 1) {
+    if(s->defs.SR.TXE == 1) {
         /* If the buffer is empty, there is nothing waiting to be transmitted.
          * Mark the transmit complete. */
-        s->USART_SR_TC = 1;
-        // if (s->uart_index==2 && s->reply_count==8 && stm32_uart_can_receive(s) == USART_RCV_BUF_LEN)
-        // {
-        //     if (s->is_read){
-        //         printf("UART2 reply\n");
-        //         uint8_t reply[8] = {0x05, 0xFF, 0x01, 0x00,0x02, 0x03, 0x04};
-        //         stm32_uart_receive(s, reply, s->is_read?8 : 4);
-        //         s->is_read = false;
-        //     }
-        //     s->reply_count =0;
-        // }
+        s->defs.SR.TC = 1;
         stm32_uart_update_irq(s);
     } else {
         /* Otherwise, mark the transmit buffer as empty and
          * start transmitting the value stored there.
          */
-        s->USART_SR_TXE = 1;
+        s->defs.SR.TXE = 1;
         stm32_uart_update_irq(s);
         stm32_uart_start_tx(s, s->USART_TDR);
   
@@ -201,8 +172,7 @@ static void stm32_uart_start_tx(Stm32Uart *s, uint32_t value)
     /* Reset the Transmission Complete flag to indicate a transmit is in
      * progress.
      */
-    s->USART_SR_TC = 0;
-
+    s->defs.SR.TC = 0;
     /* Write the character out. */
     uint8_t chcr = '\r';
     if (ch == '\n') qemu_chr_fe_write_all(&s->chr, &chcr, 1);
@@ -211,15 +181,6 @@ static void stm32_uart_start_tx(Stm32Uart *s, uint32_t value)
     // if (s->chr_write_obj) {
         // s->chr_write(s->chr_write_obj, &ch, 1);
     // }
-    if (s->uart_index==2)
-    {
-        s->reply_count++;
-        if (s->reply_count == 3 && !(value & 0x80 ))
-        {
-            s->is_read = true;
-            s->reply_count += 4;
-        }
-    }
 #ifdef STM32_UART_NO_BAUD_DELAY
     /* If BAUD delays are not being simulated, then immediately mark the
      * transmission as complete.
@@ -236,7 +197,7 @@ static void stm32_uart_start_tx(Stm32Uart *s, uint32_t value)
  * ready for it. */
 static void stm32_uart_fill_receive_data_register(Stm32Uart *s)
 {
-    bool enabled = (s->USART_CR1_UE && s->USART_CR1_RE);
+    bool enabled = (s->defs.CR1.UE && s->defs.CR1.RE);
 
     /* If we have no more data, or we are emulating baud delay and it's not 
      * time yet for the next byte, return without filling the RDR */
@@ -246,7 +207,7 @@ static void stm32_uart_fill_receive_data_register(Stm32Uart *s)
 
 #ifndef STM32_UART_ENABLE_OVERRUN
     /* If overrun is not enabled, don't overwrite the current byte in the RDR */
-    if (enabled && s->USART_SR_RXNE) {
+    if (enabled && s->defs.SR.RXNE) {
         return;
     }
 #endif
@@ -257,16 +218,16 @@ static void stm32_uart_fill_receive_data_register(Stm32Uart *s)
 
     /* Only handle the received character if the module is enabled, */
     if (enabled) {
-        if(s->USART_SR_RXNE) {
+        if(s->defs.SR.RXNE) {
             DPRINTF("stm32_uart_receive: overrun error\n");
-            s->USART_SR_ORE = 1;
+            s->defs.SR.ORE = 1;
             s->sr_read_since_ore_set = false;
             stm32_uart_update_irq(s);
         }
 
         /* Receive the character and mark the buffer as not empty. */
-        s->USART_RDR = byte;
-        s->USART_SR_RXNE = 1;
+        s->defs.DR.DR = byte;
+        s->defs.SR.RXNE = 1;
         // Clear DMAR flag so the irq gets re-raised.
         stm32_uart_update_irq(s);
     }
@@ -328,85 +289,39 @@ static void stm32_uart_receive(void *opaque, const uint8_t *buf, int size)
 
 /* REGISTER IMPLEMENTATION */
 
-static uint32_t stm32_uart_USART_SR_read(Stm32Uart *s)
-{
-    /* If the Overflow flag is set, reading the SR register is the first step
-     * to resetting the flag.
-     */
-    if(s->USART_SR_ORE) {
-        s->sr_read_since_ore_set = true;
-    }
-
-    return (s->USART_SR_TXE << USART_SR_TXE_BIT) |
-           (s->USART_SR_TC << USART_SR_TC_BIT) |
-           (s->USART_SR_RXNE << USART_SR_RXNE_BIT) |
-           (s->USART_SR_ORE << USART_SR_ORE_BIT);
-
-    qemu_chr_fe_accept_input(&s->chr);
-}
-
-
-
-
-
-static void stm32_uart_USART_SR_write(Stm32Uart *s, uint32_t new_value)
-{
-    uint32_t new_TC, new_RXNE;
-
-    new_TC = extract32(new_value, USART_SR_TC_BIT, 1);
-    /* The Transmit Complete flag can be cleared, but not set. */
-    if(new_TC) {
-        qemu_log_mask(LOG_GUEST_ERROR,"Software attempted to set USART TC bit\n");
-    } else {
-        s->USART_SR_TC = new_TC;
-    }
-
-    new_RXNE = extract32(new_value, USART_SR_RXNE_BIT, 1);
-    /* The Read Data Register Not Empty flag can be cleared, but not set. */
-    if(new_RXNE) {
-        qemu_log_mask(LOG_GUEST_ERROR,"Software attempted to set USART RXNE bit\n");
-    } else { 
-        s->USART_SR_RXNE = new_RXNE;
-    }
-
-    stm32_uart_update_irq(s);
-}
-
-
-static void stm32_uart_USART_DR_read(Stm32Uart *s, uint32_t *read_value)
+static void stm32_uart_USART_DR_read(Stm32Uart *s, uint8_t *data_read)
 {
     /* If the Overflow flag is set, then it should be cleared if the software
      * performs an SR read followed by a DR read.
      */
 
-    if(s->USART_SR_ORE) {
+    if(s->defs.SR.ORE) {
         if(s->sr_read_since_ore_set) {
-            s->USART_SR_ORE = 0;
-
+            s->defs.SR.ORE = 0;
         }
     }
 
-    if(!s->USART_CR1_UE) {
-        qemu_log_mask(LOG_GUEST_ERROR,"Attempted to read from USART_DR while UART was disabled.");
+    if(!s->defs.CR1.UE) {
+        qemu_log_mask(LOG_GUEST_ERROR,"Attempted to read from USART_DR while UART was disabled.\n");
     }
 
-    if(!s->USART_CR1_RE) {
-        qemu_log_mask(LOG_GUEST_ERROR,"Attempted to read from USART_DR while UART receiver was disabled.");
+    if(!s->defs.CR1.RE) {
+        qemu_log_mask(LOG_GUEST_ERROR,"Attempted to read from USART_DR while UART receiver was disabled.\n");
     }
-    if(s->USART_SR_RXNE) {
+    if(s->defs.SR.RXNE) {
         /* If the receive buffer is not empty, return the value. and mark the
          * buffer as empty.
          */
-        (*read_value) = s->USART_RDR;
-
         // printf("DR read: %02x\n", *read_value);
 
-        s->USART_SR_RXNE = 0;
+        s->defs.SR.RXNE = 0;
 
+        *data_read = s->defs.DR.DR;
         /* Put next character into the RDR if we have one */
         stm32_uart_fill_receive_data_register(s);
     } else {
         printf("STM32_UART WARNING: Read value from USART_DR (%08lx) while it was empty.\n", s->iomem.addr);
+        s->defs.DR.DR = 0; // Clear value.
     }
 
     qemu_chr_fe_accept_input(&s->chr);
@@ -419,16 +334,16 @@ static void stm32_uart_USART_DR_write(Stm32Uart *s, uint32_t new_value)
     uint32_t write_value = new_value & 0x000001ff;
     //printf("uart %d: wr: %02x\n",s->uart_index, write_value);
 
-    if(!s->USART_CR1_UE) {
+    if(!s->defs.CR1.UE) {
         qemu_log_mask(LOG_GUEST_ERROR,"Attempted to write to USART_DR while UART was disabled.");
     }
 
-    if(!s->USART_CR1_TE) {
+    if(!s->defs.CR1.TE) {
         qemu_log_mask(LOG_GUEST_ERROR,"Attempted to write to USART_DR while UART transmitter "
                  "was disabled.");
     }
 
-    if(s->USART_SR_TC) {
+    if(s->defs.SR.TC) {
         /* If the Transmission Complete bit is set, it means the USART is not
          * currently transmitting.  This means, a transmission can immediately
          * start.
@@ -440,62 +355,15 @@ static void stm32_uart_USART_DR_write(Stm32Uart *s, uint32_t new_value)
          * If it is not empty, trigger a hardware error.  Software should check
          * to make sure it is empty before writing to the Data Register.
          */
-        if(s->USART_SR_TXE) {
+        if(s->defs.SR.TXE) {
             s->USART_TDR = write_value;
-            s->USART_SR_TXE = 0;
+            s->defs.SR.TXE = 0;
         } else {
             qemu_log_mask(LOG_GUEST_ERROR,"Wrote new value to USART_DR while it was non-empty.\n");
         }
     }
 
     stm32_uart_update_irq(s);
-}
-
-/* Update the Baud Rate Register. */
-static void stm32_uart_USART_BRR_write(Stm32Uart *s, uint32_t new_value,
-                                        bool init)
-{
-    s->USART_BRR = new_value & 0x0000ffff;
-
-    stm32_uart_baud_update(s);
-}
-
-static void stm32_uart_USART_CR1_write(Stm32Uart *s, uint32_t new_value,
-                                        bool init)
-{
-    s->USART_CR1_UE = extract32(new_value, USART_CR1_UE_BIT, 1);
-#if 0 /* XXX Does not work with f2xx yet */
-    if(s->USART_CR1_UE) {
-        /* Check to make sure the correct mapping is selected when enabling the
-         * USART.
-         */
-        if(s->afio_board_map != stm32_afio_get_periph_map(s->stm32_afio, s->periph)) {
-            hw_error("Bad AFIO mapping for %s", s->busdev.parent_obj.id);
-        }
-    }
-#endif
-
-    s->USART_CR1_TXEIE = extract32(new_value, USART_CR1_TXEIE_BIT, 1);
-    s->USART_CR1_TCIE = extract32(new_value, USART_CR1_TCIE_BIT, 1);
-    s->USART_CR1_RXNEIE = extract32(new_value, USART_CR1_RXNEIE_BIT, 1);
-
-    s->USART_CR1_TE = s->USART_SR_TC = extract32(new_value, USART_CR1_TE_BIT, 1);
-    s->USART_CR1_RE = extract32(new_value, USART_CR1_RE_BIT, 1);
-    s->USART_CR1 = new_value & 0x00003fff;
-
-     stm32_uart_update_irq(s);
-}
-
-static void stm32_uart_USART_CR2_write(Stm32Uart *s, uint32_t new_value,
-                                        bool init)
-{
-    s->USART_CR2 = new_value & 0x00007f7f;
-}
-
-static void stm32_uart_USART_CR3_write(Stm32Uart *s, uint32_t new_value,
-                                        bool init)
-{
-    s->USART_CR3 = new_value & 0x000007ff;
 }
 
 static void stm32_uart_reset(DeviceState *dev)
@@ -506,98 +374,118 @@ static void stm32_uart_reset(DeviceState *dev)
      * read-only, so we do not call the "write" routine
      * like normal.
      */
-    s->USART_SR_TXE = 1;
-    s->USART_SR_TC = 1;
-    s->USART_SR_RXNE = 0;
-    s->USART_SR_ORE = 0;
-
+    for (int i=0; i<7; i++) {
+        s->regs[i] = 0;
+    }
+    s->defs.SR.TC = 1;
+    s->defs.SR.TXE = 1;
+    
     s->dmar_current_level = -1;
 
     // Do not initialize USART_DR - it is documented as undefined at reset
     // and does not behave like normal registers.
-    stm32_uart_USART_BRR_write(s, 0x00000000, true);
-    stm32_uart_USART_CR1_write(s, 0x00000000, true);
-    stm32_uart_USART_CR2_write(s, 0x00000000, true);
-    stm32_uart_USART_CR3_write(s, 0x00000000, true);
-
-    s->reply_count=0;
-    s->reply  = 0x50FF0100;
+    //stm32_uart_USART_BRR_write(s, 0x00000000, true);
 
     stm32_uart_update_irq(s);
 }
 
-static uint64_t stm32_uart_read(void *opaque, hwaddr offset,
+static uint64_t stm32_uart_read(void *opaque, hwaddr addr,
                           unsigned size)
 {
     Stm32Uart *s = (Stm32Uart *)opaque;
-    uint32_t value = 0;
-    int start = (offset & 3) * 8;
-    int length = size * 8;
+    int offset = addr & 0x3;
+    addr >>= 2;
 
-    switch (offset & 0xfffffffc) {
-        case USART_SR_OFFSET:
-            return extract64(stm32_uart_USART_SR_read(s), start, length);
-        case USART_DR_OFFSET:
-            stm32_uart_USART_DR_read(s, &value);
-            return extract64(value, start, length);
-        case USART_BRR_OFFSET:
-            return extract64(s->USART_BRR, start, length);
-        case USART_CR1_OFFSET:
-            return extract64(s->USART_CR1, start, length);
-        case USART_CR2_OFFSET:
-            return extract64(s->USART_CR2, start, length);
-        case USART_CR3_OFFSET:
-            return extract64(s->USART_CR3, start, length);
-        case USART_GTPR_OFFSET:
-            STM32_NOT_IMPL_REG(offset, size);
-            return 0;
-        default:
-            STM32_BAD_REG(offset, size);
-            return 0;
+    if (addr >= USART_R_END) {
+        qemu_log_mask(LOG_GUEST_ERROR, "invalid read usart register 0x%x\n",
+          (unsigned int)addr << 2);
+        DPRINTF("  %s: result: 0\n", __func__);
+        return 0;
     }
+
+    switch (addr) {
+        case USART_SR_OFFSET:
+            if(s->defs.SR.ORE) {
+                s->sr_read_since_ore_set = true;
+            }
+            qemu_chr_fe_accept_input(&s->chr);
+            break;
+        case USART_DR_OFFSET:
+            {
+                uint8_t value = 0;
+                stm32_uart_USART_DR_read(s, &value);
+                return value;
+            }
+            break;
+    }
+
+    uint32_t value = s->regs[addr];
+
+    value = (value >> offset * 8) & ((1ull << (8 * size)) - 1);
+
+    DPRINTF("%s: addr: 0x%llx, size: %u, value: 0x%x\n", __func__, addr, size, value);
+    return value;
+
 }
 
-static void stm32_uart_write(void *opaque, hwaddr offset,
+static void stm32_uart_write(void *opaque, hwaddr addr,
                        uint64_t value, unsigned size)
 {
     Stm32Uart *s = (Stm32Uart *)opaque;
-    int start = (offset & 3) * 8;
-    int length = size * 8;
+    int offset = addr & 0x3;
+    uint32_t data = 0;
+    DPRINTF("%s: addr: 0x%llx, data: 0x%lx, size: %u\n", __func__, addr, data, size);
+
+    addr >>= 2;
+    if (addr >= USART_R_END) {
+        qemu_log_mask(LOG_GUEST_ERROR, "invalid write f2xx usart register 0x%x\n",
+            (unsigned int)addr << 2);
+        return;
+    }
+
+    switch(size) {
+    case 1:
+        data = (s->regs[addr] & ~(0xff << (offset * 8))) | data << (offset * 8);
+        break;
+    case 2:
+        data = (s->regs[addr] & ~(0xffff << (offset * 8))) | data << (offset * 8);
+        break;
+    case 4:
+        data = value;
+        break;
+    default:
+        abort();
+    }
+
     if (s->stm32_rcc)
         stm32_rcc_check_periph_clk(s->stm32_rcc, s->periph);
 
-    switch (offset & 0xfffffffc) {
+    switch (addr) {
         case USART_SR_OFFSET:
-            stm32_uart_USART_SR_write(s,
-                  deposit64(stm32_uart_USART_SR_read(s), start, length, value));
+            // Check write mask to see if guest tried to set a clear-only bit
+            if ((value & ~(s->regs[USART_SR_OFFSET])) & 0x360) {
+                qemu_log_mask(LOG_GUEST_ERROR, "USART - guest attempted to set a clear-only SR bit with value %0" HWADDR_PRIx "\n", value);
+                value |= 0x360;
+            }
+            s->regs[addr] &= value;
+            stm32_uart_update_irq(s);
             break;
         case USART_DR_OFFSET:
-            stm32_uart_USART_DR_write(s,
-                  deposit64(0, start, length, value));
+            stm32_uart_USART_DR_write(s,value);
             break;
         case USART_BRR_OFFSET:
-            stm32_uart_USART_BRR_write(s,
-                  deposit64(s->USART_BRR, start, length, value), false);
+            s->regs[addr] = data;
+            stm32_uart_baud_update(s);
             break;
         case USART_CR1_OFFSET:
-            stm32_uart_USART_CR1_write(s,
-                  deposit64(s->USART_CR1, start, length, value), false);
-            break;
-        case USART_CR2_OFFSET:
-            stm32_uart_USART_CR2_write(s,
-                  deposit64(s->USART_CR2, start, length, value), false);
-            break;
-        case USART_CR3_OFFSET:
-            stm32_uart_USART_CR3_write(s,
-                  deposit64(s->USART_CR3, start, length, value), false);
-            break;
-        case USART_GTPR_OFFSET:
-            STM32_NOT_IMPL_REG(offset, 2U);
+            s->regs[addr] = data;
+            stm32_uart_update_irq(s);
             break;
         default:
-            STM32_BAD_REG(offset, 2U);
+            s->regs[addr] = data;
             break;
     }
+
 }
 
 static const MemoryRegionOps stm32_uart_ops = {
@@ -665,13 +553,43 @@ static void stm32_uart_realize(DeviceState *dev, Error **errp)
     qemu_chr_fe_set_handlers(&s->chr, stm32_uart_can_receive, stm32_uart_receive, NULL,
             NULL,s,NULL,true);
     qemu_chr_fe_set_echo(&s->chr, true);
+    // Throw compile errors if alignment is off
+    CHECK_ALIGN(sizeof(s->defs), sizeof(s->regs), "USART");
+    CHECK_ALIGN(sizeof(uint32_t)*7, sizeof(s->regs), "USART");
+    CHECK_REG_u32(s->defs.SR);
+    CHECK_REG_u32(s->defs.DR);
+    CHECK_REG_u32(s->defs.BRR);
+    CHECK_REG_u32(s->defs.CR1);
+    CHECK_REG_u32(s->defs.CR2);
+    CHECK_REG_u32(s->defs.CR3);
+    CHECK_REG_u32(s->defs.GPTR);
 }
 
 static Property stm32_uart_properties[] = {
-    // DEFINE_PROP_PTR("stm32_rcc", Stm32Uart, stm32_rcc_prop),
     DEFINE_PROP_CHR("chardev", Stm32Uart, chr),
-    DEFINE_PROP_INT32("index", Stm32Uart, uart_index,0),
     DEFINE_PROP_END_OF_LIST()
+};
+
+static const VMStateDescription vmstate_stm32_uart = {
+    .name = TYPE_STM32_UART,
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .fields = (VMStateField[]) {
+        VMSTATE_UINT32_ARRAY(regs, Stm32Uart,USART_R_END),
+        VMSTATE_INT32(periph,Stm32Uart),
+        VMSTATE_UINT32(bits_per_sec,Stm32Uart),
+        VMSTATE_INT64(ns_per_char,Stm32Uart),
+        VMSTATE_UINT32(USART_TDR,Stm32Uart),
+        VMSTATE_BOOL(sr_read_since_ore_set,Stm32Uart),
+        VMSTATE_BOOL(receiving,Stm32Uart),
+        VMSTATE_TIMER_PTR(rx_timer,Stm32Uart),
+        VMSTATE_TIMER_PTR(tx_timer,Stm32Uart),
+        VMSTATE_INT32(curr_irq_level,Stm32Uart),
+        VMSTATE_INT32(dmar_current_level,Stm32Uart),
+        VMSTATE_UINT8_ARRAY(rcv_char_buf,Stm32Uart,USART_RCV_BUF_LEN),
+        VMSTATE_UINT32(rcv_char_bytes,Stm32Uart),
+        VMSTATE_END_OF_LIST()
+    }
 };
 
 static void stm32_uart_class_init(ObjectClass *klass, void *data)
@@ -680,6 +598,7 @@ static void stm32_uart_class_init(ObjectClass *klass, void *data)
     dc->reset = stm32_uart_reset;
     device_class_set_props(dc, stm32_uart_properties);
     dc->realize = stm32_uart_realize;
+    dc->vmsd = &vmstate_stm32_uart;
 }
 
 static TypeInfo stm32_uart_info = {

--- a/hw/arm/prusa/stm32f407/stm32_uart.h
+++ b/hw/arm/prusa/stm32f407/stm32_uart.h
@@ -38,19 +38,91 @@ struct Stm32Uart {
     /* Inherited */
     SysBusDevice busdev;
 
-    /* Properties */
-    // void *stm32_rcc_prop;
-
     /* Private */
     MemoryRegion iomem;
 
     Stm32Rcc *stm32_rcc;
 
-    int uart_index;
-
-    uint8_t reply_count;
-    uint32_t reply;
-    bool is_read;
+    union {
+        uint32_t regs[7];
+        struct {
+            struct {
+                uint32_t PE     :1;
+                uint32_t FE     :1;
+                uint32_t NF     :1;
+                uint32_t ORE    :1;
+                uint32_t IDLE   :1;
+                uint32_t RXNE   :1;
+                uint32_t TC     :1;
+                uint32_t TXE    :1;
+                uint32_t LBD    :1;
+                uint32_t CTS    :1;
+                uint32_t :22;
+            } QEMU_PACKED SR;
+            struct {
+                uint32_t DR :8;
+                uint32_t :24;
+            } QEMU_PACKED DR; // Note - this is the R DR. TXDR is separate.
+            struct {
+                uint32_t FRACT  :4;
+                uint32_t MANT   :12;
+                uint32_t :16; 
+            } QEMU_PACKED BRR;
+            struct {
+                uint32_t SBK    :1;
+                uint32_t RWU    :1;
+                uint32_t RE     :1;
+                uint32_t TE     :1;
+                uint32_t IDLEIE :1;
+                uint32_t RXNEIE :1;
+                uint32_t TCIE   :1;
+                uint32_t TXEIE   :1;
+                uint32_t PEIE   :1;
+                uint32_t PS     :1;
+                uint32_t PCE    :1;
+                uint32_t WAKE   :1;
+                uint32_t M      :1;
+                uint32_t UE     :1;
+                uint32_t _reserved :1;
+                uint32_t OVER8  :1;
+                uint16_t :16;
+            } QEMU_PACKED CR1;
+            struct {
+                uint32_t ADD    :4;
+                uint32_t _res   :1;
+                uint32_t LBDL   :1;
+                uint32_t LBDIE  :1;
+                uint32_t _res1  :1;
+                uint32_t LBCL   :1;
+                uint32_t CPHA   :1;
+                uint32_t CPOL   :1;
+                uint32_t CLKEN  :1;
+                uint32_t STOP   :2;
+                uint32_t LINEN  :1;
+                uint32_t :17;
+            } QEMU_PACKED CR2;
+            struct {
+                uint32_t EIE    :1;
+                uint32_t IREN   :1;
+                uint32_t IRLP   :1;
+                uint32_t HDSEL  :1;
+                uint32_t NACK   :1;
+                uint32_t SCEN   :1;
+                uint32_t DMAR   :1;
+                uint32_t DMAT   :1;
+                uint32_t RTSE   :1;
+                uint32_t CTSE   :1;
+                uint32_t CTSIE  :1;
+                uint32_t CNEBI  :1;
+                uint32_t :20;
+            } QEMU_PACKED CR3;
+            struct {
+                uint32_t PSC    :8;
+                uint32_t GT     :8;
+                uint32_t :16;
+            } QEMU_PACKED GPTR;
+        } QEMU_PACKED defs;
+    };
 
     stm32_periph_t periph;
 
@@ -58,27 +130,8 @@ struct Stm32Uart {
     int64_t ns_per_char;
 
     /* Register Values */
-    uint32_t
-        USART_RDR,
-        USART_TDR,
-        USART_BRR,
-        USART_CR1,
-        USART_CR2,
-        USART_CR3;
-
-    /* Register Field Values */
-    uint32_t
-        USART_SR_TXE,
-        USART_SR_TC,
-        USART_SR_RXNE,
-        USART_SR_ORE,
-        USART_CR1_UE,
-        USART_CR1_TXEIE,
-        USART_CR1_TCIE,
-        USART_CR1_RXNEIE,
-        USART_CR1_TE,
-        USART_CR1_RE;
-
+    uint32_t USART_TDR;
+        
     bool sr_read_since_ore_set;
 
     /* Indicates whether the USART is currently receiving a byte. */

--- a/hw/arm/prusa/stm32f407/stm32f2xx_crc.c
+++ b/hw/arm/prusa/stm32f407/stm32f2xx_crc.c
@@ -23,6 +23,7 @@
  */
 
 #include "stm32f2xx_crc.h"
+#include "migration/vmstate.h"
 #include "qemu/log.h"
 
 #define R_CRC_DR            (0x00 / 4)
@@ -192,11 +193,24 @@ f2xx_crc_reset(DeviceState *ds)
     s->crc = R_CRC_DR_RESET;
 }
 
+static const VMStateDescription vmstate_stm32f2xx_crc = {
+    .name = TYPE_STM32F2XX_CRC,
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .fields = (VMStateField[]) {
+        VMSTATE_UINT32(crc, f2xx_crc),
+        VMSTATE_UINT8(idr, f2xx_crc),
+        VMSTATE_END_OF_LIST()
+    }
+};
+
+
 static void
 f2xx_crc_class_init(ObjectClass *klass, void *data)
 {
     DeviceClass *dc = DEVICE_CLASS(klass);
     dc->reset = f2xx_crc_reset;
+    dc->vmsd = &vmstate_stm32f2xx_crc;
 }
 
 static const TypeInfo

--- a/hw/arm/prusa/stm32f407/stm32f2xx_flashint.c
+++ b/hw/arm/prusa/stm32f407/stm32f2xx_flashint.c
@@ -22,6 +22,7 @@
 
 #include "stm32f2xx_flashint.h"
 #include "hw/irq.h"
+#include "migration/vmstate.h"
 #include "qemu/log.h"
 
 //#define DEBUG_STM32_FINT
@@ -110,11 +111,23 @@ stm32f2xx_fint_init(Object *obj)
     sysbus_init_mmio(SYS_BUS_DEVICE(obj), &s->iomem);
 }
 
+static const VMStateDescription vmstate_stm32f2xx_fint = {
+    .name = TYPE_STM32F2XX_FINT,
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .fields = (VMStateField[]) {
+        VMSTATE_UINT32_ARRAY(regs, stm32f2xx_fint,STM32_FINT_MAX),
+        VMSTATE_END_OF_LIST()
+    }
+};
+
+
 static void
 stm32f2xx_fint_class_init(ObjectClass *klass, void *data)
 {
     DeviceClass *dc = DEVICE_CLASS(klass);
     dc->reset = stm32f2xx_fint_reset;
+    dc->vmsd = &vmstate_stm32f2xx_fint;
 }
 
 static const TypeInfo stm32f2xx_fint_info = {

--- a/hw/arm/prusa/stm32f407/stm32f2xx_gpio.c
+++ b/hw/arm/prusa/stm32f407/stm32f2xx_gpio.c
@@ -25,6 +25,7 @@
 #include "stm32f2xx_gpio.h"
 #include "hw/irq.h"
 #include "qemu/log.h"
+#include "migration/vmstate.h"
 #include "hw/qdev-properties.h"
 //#include "hw/arm/stm32.h"
 
@@ -231,11 +232,26 @@ static Property stm32f2xx_gpio_properties[] = {
     DEFINE_PROP_END_OF_LIST()
 };
 
+static const VMStateDescription vmstate_stm32f2xx_gpio = {
+    .name = TYPE_STM32F2XX_GPIO,
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .fields = (VMStateField[]) {
+        VMSTATE_UINT32(periph, stm32f2xx_gpio),
+        VMSTATE_UINT32(idr_mask, stm32f2xx_gpio),
+        VMSTATE_UINT32_ARRAY(regs, stm32f2xx_gpio,STM32_GPIO_MAX),
+        VMSTATE_UINT32(ccr, stm32f2xx_gpio),
+        VMSTATE_END_OF_LIST()
+    }
+};
+
+
 static void
 stm32f2xx_gpio_class_init(ObjectClass *klass, void *data)
 {
     DeviceClass *dc = DEVICE_CLASS(klass);
     dc->reset = stm32f2xx_gpio_reset;
+    dc->vmsd = &vmstate_stm32f2xx_gpio;
     device_class_set_props(dc, stm32f2xx_gpio_properties);
 }
 

--- a/hw/arm/prusa/stm32f407/stm32f2xx_i2c.c
+++ b/hw/arm/prusa/stm32f407/stm32f2xx_i2c.c
@@ -30,6 +30,7 @@
 #include "hw/irq.h"
 #include "hw/i2c/i2c.h"
 #include "hw/sysbus.h"
+#include "migration/vmstate.h"
 #include "stm32_util.h"
 #include "stm32f2xx_i2c.h"
 #include "../utility/macros.h"
@@ -345,9 +346,27 @@ stm32f2xxi2c_init(Object *obj)
     s->bus = i2c_init_bus(dev, "i2c");
 }
 
+static const VMStateDescription vmstate_stm32f2xx_i2c = {
+    .name = TYPE_STM32F2XX_I2C,
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .fields = (VMStateField[]) {
+        VMSTATE_UINT16_ARRAY(regs,STM32F2XXI2CState,R_I2C_COUNT),
+        VMSTATE_UINT8(last_read,STM32F2XXI2CState),
+        VMSTATE_UINT8(slave_address,STM32F2XXI2CState),
+        VMSTATE_UINT8(shiftreg,STM32F2XXI2CState),
+        VMSTATE_INT32(rx,STM32F2XXI2CState),
+        VMSTATE_BOOL(shift_full,STM32F2XXI2CState),
+        VMSTATE_BOOL(is_read,STM32F2XXI2CState),
+        VMSTATE_BOOL(dr_unread,STM32F2XXI2CState),
+        VMSTATE_END_OF_LIST()
+    }
+};
+
 static void
 stm32f2xxi2c_class_init(ObjectClass *c, void *data)
 {
     DeviceClass *dc = DEVICE_CLASS(c);
+    dc->vmsd = &vmstate_stm32f2xx_i2c;
     dc->reset = stm32f2xxi2c_reset;
 }

--- a/hw/arm/prusa/stm32f407/stm32f2xx_pwr.c
+++ b/hw/arm/prusa/stm32f407/stm32f2xx_pwr.c
@@ -24,6 +24,7 @@
 
 
 #include "stm32f2xx_pwr.h"
+#include "migration/vmstate.h"
 #include "qemu/log.h"
 
 //#define DEBUG_STM32F2XX_PWR
@@ -144,11 +145,22 @@ f2xx_pwr_init(Object *obj)
     s->regs[R_PWR_CSR] = 0;
 }
 
+static const VMStateDescription vmstate_stm32f2xx_pwr = {
+    .name = TYPE_STM32F2XX_PWR,
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .fields = (VMStateField[]) {
+        VMSTATE_UINT32_ARRAY(regs, f2xx_pwr,R_PWR_MAX),
+        VMSTATE_END_OF_LIST()
+    }
+};
+
 static void
 f2xx_pwr_class_init(ObjectClass *klass, void *data)
 {
     DeviceClass *dc = DEVICE_CLASS(klass);
     dc->reset = f2xx_pwr_reset;
+    dc->vmsd = &vmstate_stm32f2xx_pwr;
 }
 
 static const TypeInfo

--- a/hw/arm/prusa/stm32f407/stm32f2xx_rcc.c
+++ b/hw/arm/prusa/stm32f407/stm32f2xx_rcc.c
@@ -30,7 +30,8 @@
 #include "qemu/log.h"
 #include "qemu/module.h"
 #include "hw/irq.h"
-
+// #define STATE_DEBUG_VAR rcc_dbg
+#include "../utility/macros.h"
 
 /* DEFINITIONS*/
 
@@ -298,26 +299,8 @@ do { printf("STM32F2XX_RCC: " fmt , ## __VA_ARGS__); } while (0)
 #define SW_PLL_SELECTED 2
 
 /* HELPER FUNCTIONS */
-struct Clk {                                                                    
-    const char *name;                                                           
-                                                                                
-    bool enabled;                                                               
-                                                                                
-    uint32_t input_freq, output_freq, max_output_freq;                          
-                                                                                
-    uint16_t multiplier, divisor;                                               
-                                                                                
-    unsigned user_count;                                                        
-    qemu_irq user[CLKTREE_MAX_IRQ]; /* Who to notify on change */               
-                                                                                
-    unsigned output_count;                                                      
-    struct Clk *output[CLKTREE_MAX_OUTPUT];                                     
-                                                                                
-    unsigned input_count;                                                       
-    int selected_input;                                                         
-    struct Clk *input[CLKTREE_MAX_INPUT];                                       
-};                                                                              
-                                                                                
+
+DEBUG_COPY(Stm32f2xxRcc,1);                                                                                
 
 /* Enable the peripheral clock if the specified bit is set in the value. */
 static void stm32_rcc_periph_enable(
@@ -328,7 +311,7 @@ static void stm32_rcc_periph_enable(
                                     uint32_t bit_mask)
 {
     //printf("rcc set 0x%x %s %d %x: %sable\n", new_value, s->PERIPHCLK[periph]->name, periph, bit_mask, IS_BIT_SET(new_value, bit_mask)?"en":"dis");
-    clktree_set_enabled(s->PERIPHCLK[periph], IS_BIT_SET(new_value, bit_mask));
+    clktree_set_enabled(&s->PERIPHCLK[periph], IS_BIT_SET(new_value, bit_mask));
 }
 
 
@@ -342,10 +325,10 @@ static void stm32_rcc_periph_enable(
 static uint32_t stm32_rcc_RCC_CR_read(Stm32f2xxRcc *s)
 {
     /* Get the status of the clocks. */
-    const bool PLLON = clktree_is_enabled(s->PLLCLK);
-    const bool HSEON = clktree_is_enabled(s->HSECLK);
-    const bool HSION = clktree_is_enabled(s->HSICLK);
-    const bool PLLI2SON = clktree_is_enabled(s->PLLI2SCLK);
+    const bool PLLON = clktree_is_enabled(&s->PLLCLK);
+    const bool HSEON = clktree_is_enabled(&s->HSECLK);
+    const bool HSION = clktree_is_enabled(&s->HSICLK);
+    const bool PLLI2SON = clktree_is_enabled(&s->PLLI2SCLK);
 
     /* build the register value based on the clock states.  If a clock is on,
      * then its ready bit is always set.
@@ -375,30 +358,30 @@ static void stm32_rcc_RCC_CR_write(Stm32f2xxRcc *s, uint32_t new_value, bool ini
     bool new_PLLON, new_HSEON, new_HSION, new_PLLI2SON;
 
     new_PLLON = IS_BIT_SET(new_value, RCC_CR_PLLON_BIT);
-    if((clktree_is_enabled(s->PLLCLK) && !new_PLLON) &&
+    if((clktree_is_enabled(&s->PLLCLK) && !new_PLLON) &&
        s->RCC_CFGR_SW == SW_PLL_SELECTED) {
         printf("PLL cannot be disabled while it is selected as the system clock.");
     }
-    clktree_set_enabled(s->PLLCLK, new_PLLON);
+    clktree_set_enabled(&s->PLLCLK, new_PLLON);
 
     new_HSEON = IS_BIT_SET(new_value, RCC_CR_HSEON_BIT);
-    if((clktree_is_enabled(s->HSECLK) && !new_HSEON) &&
+    if((clktree_is_enabled(&s->HSECLK) && !new_HSEON) &&
        (s->RCC_CFGR_SW == SW_HSE_SELECTED || s->RCC_CFGR_SW == SW_PLL_SELECTED)
        ) {
         printf("HSE oscillator cannot be disabled while it is driving the system clock.");
     }
-    clktree_set_enabled(s->HSECLK, new_HSEON);
+    clktree_set_enabled(&s->HSECLK, new_HSEON);
 
     new_HSION = IS_BIT_SET(new_value, RCC_CR_HSION_BIT);
-    if((clktree_is_enabled(s->HSECLK) && !new_HSEON) &&
+    if((clktree_is_enabled(&s->HSECLK) && !new_HSEON) &&
        (s->RCC_CFGR_SW == SW_HSI_SELECTED || s->RCC_CFGR_SW == SW_PLL_SELECTED)
        ) {
         printf("HSI oscillator cannot be disabled while it is driving the system clock.");
     }
-    clktree_set_enabled(s->HSICLK, new_HSION);
+    clktree_set_enabled(&s->HSICLK, new_HSION);
 
     new_PLLI2SON = IS_BIT_SET(new_value, RCC_CR_PLLI2SON_BIT);
-    clktree_set_enabled(s->PLLI2SCLK, new_PLLI2SON);
+    clktree_set_enabled(&s->PLLI2SCLK, new_PLLI2SON);
 
     WARN_UNIMPLEMENTED(new_value, 1 << RCC_CR_CSSON_BIT, RCC_CR_RESET_VALUE);
     WARN_UNIMPLEMENTED(new_value, RCC_CR_HSICAL_MASK, RCC_CR_RESET_VALUE);
@@ -433,7 +416,7 @@ static void stm32_rcc_RCC_PLLCFGR_write(Stm32f2xxRcc *s, uint32_t new_value, boo
 
     /* Warn in case of illegal writes: */
     if (init == false) {
-        const bool are_disabled = (!clktree_is_enabled(s->PLLCLK) /* && TODO: !clktree_is_enabled(s->PLLI2SCLK) */);
+        const bool are_disabled = (!clktree_is_enabled(&s->PLLCLK) /* && TODO: !clktree_is_enabled(s->PLLI2SCLK) */);
         if (are_disabled == false) {
             const char *warning_fmt = "Can only change %s while PLL and PLLI2S are disabled";
             if (new_PLLM != s->RCC_PLLCFGR_PLLM) {
@@ -454,13 +437,13 @@ static void stm32_rcc_RCC_PLLCFGR_write(Stm32f2xxRcc *s, uint32_t new_value, boo
     /* Set the new values: */
     s->RCC_PLLCFGR_PLLM = new_PLLM;
     s->RCC_PLLCFGR_PLLN = new_PLLN;
-    clktree_set_scale(s->PLLM, new_PLLN, new_PLLM);
+    clktree_set_scale(&s->PLLM, new_PLLN, new_PLLM);
 
     s->RCC_PLLCFGR_PLLSRC = new_PLLSRC;
-    clktree_set_selected_input(s->PLLM, new_PLLSRC);
+    clktree_set_selected_input(&s->PLLM, new_PLLSRC);
 
     s->RCC_PLLCFGR_PLLP = new_PLLP;
-    clktree_set_scale(s->PLLCLK, 1, new_PLLP);
+    clktree_set_scale(&s->PLLCLK, 1, new_PLLP);
 
     WARN_UNIMPLEMENTED(new_value, RCC_PLLCFGR_PLLQ_MASK, RCC_PLLCFGR_RESET_VALUE);
 }
@@ -496,7 +479,7 @@ static void stm32_rcc_RCC_PLLI2SCFGR_write(Stm32f2xxRcc *s, uint32_t new_value, 
 
     /* Warn in case of illegal writes: */
     if (init == false) {
-        const bool are_disabled = (!clktree_is_enabled(s->PLLI2SCLK) /* && TODO: !clktree_is_enabled(s->PLLI2SCLK) */);
+        const bool are_disabled = (!clktree_is_enabled(&s->PLLI2SCLK) /* && TODO: !clktree_is_enabled(s->PLLI2SCLK) */);
         if (are_disabled == false) {
             const char *warning_fmt = "Can only change %s while PLL and PLLI2S are disabled";
             if (new_PLLR != s->RCC_PLLI2SCFGR_PLLR) {
@@ -518,9 +501,9 @@ static void stm32_rcc_RCC_PLLI2SCFGR_write(Stm32f2xxRcc *s, uint32_t new_value, 
     s->RCC_PLLI2SCFGR_PLLR = new_PLLR;
     s->RCC_PLLI2SCFGR_PLLQ = new_PLLQ;
     s->RCC_PLLI2SCFGR_PLLN = new_PLLN;
-    clktree_set_scale(s->PLLI2SM, new_PLLN, s->RCC_PLLCFGR_PLLM );
+    clktree_set_scale(&s->PLLI2SM, new_PLLN, s->RCC_PLLCFGR_PLLM );
 
-    clktree_set_scale(s->PLLI2SCLK, 1, new_PLLR);
+    clktree_set_scale(&s->PLLI2SCLK, 1, new_PLLR);
     WARN_UNIMPLEMENTED(new_value, RCC_PLLI2SCFGR_PLLQ_MASK, RCC_PLLI2SCFGR_RESET_VALUE);
 }
 
@@ -540,25 +523,25 @@ static void stm32_rcc_RCC_CFGR_write(Stm32f2xxRcc *s, uint32_t new_value, bool i
     /* PPRE2 */
     s->RCC_CFGR_PPRE2 = (new_value & RCC_CFGR_PPRE2_MASK) >> RCC_CFGR_PPRE2_START;
     if(s->RCC_CFGR_PPRE2 < 0x4) {
-        clktree_set_scale(s->PCLK2, 1, 1);
+        clktree_set_scale(&s->PCLK2, 1, 1);
     } else {
-        clktree_set_scale(s->PCLK2, 1, 2 * (s->RCC_CFGR_PPRE2 - 3));
+        clktree_set_scale(&s->PCLK2, 1, 2 * (s->RCC_CFGR_PPRE2 - 3));
     }
 
     /* PPRE1 */
     s->RCC_CFGR_PPRE1 = (new_value & RCC_CFGR_PPRE1_MASK) >> RCC_CFGR_PPRE1_START;
     if(s->RCC_CFGR_PPRE1 < 4) {
-        clktree_set_scale(s->PCLK1, 1, 1);
+        clktree_set_scale(&s->PCLK1, 1, 1);
     } else {
-        clktree_set_scale(s->PCLK1, 1, 2 * (s->RCC_CFGR_PPRE1 - 3));
+        clktree_set_scale(&s->PCLK1, 1, 2 * (s->RCC_CFGR_PPRE1 - 3));
     }
 
     /* HPRE */
     s->RCC_CFGR_HPRE = (new_value & RCC_CFGR_HPRE_MASK) >> RCC_CFGR_HPRE_START;
     if(s->RCC_CFGR_HPRE < 8) {
-        clktree_set_scale(s->HCLK, 1, 1);
+        clktree_set_scale(&s->HCLK, 1, 1);
     } else {
-        clktree_set_scale(s->HCLK, 1, 2 * (s->RCC_CFGR_HPRE - 7));
+        clktree_set_scale(&s->HCLK, 1, 2 * (s->RCC_CFGR_HPRE - 7));
     }
 
     /* SW */
@@ -567,7 +550,7 @@ static void stm32_rcc_RCC_CFGR_write(Stm32f2xxRcc *s, uint32_t new_value, bool i
         case 0x0:
         case 0x1:
         case 0x2:
-            clktree_set_selected_input(s->SYSCLK, s->RCC_CFGR_SW);
+            clktree_set_selected_input(&s->SYSCLK, s->RCC_CFGR_SW);
             break;
         default:
             printf("Invalid input selected for SYSCLK");
@@ -629,22 +612,20 @@ static uint32_t stm32_rcc_RCC_AHB3ENR_read(Stm32f2xxRcc *s)
 
 static void stm32_rcc_RCC_AHB1ENR_write(Stm32f2xxRcc *s, uint32_t new_value, bool init)
 {
-    clktree_set_enabled(s->PERIPHCLK[STM32_DMA2], IS_BIT_SET(new_value, RCC_AHB1ENR_DMA2EN_BIT));
-    clktree_set_enabled(s->PERIPHCLK[STM32_DMA1], IS_BIT_SET(new_value, RCC_AHB1ENR_DMA1EN_BIT));
-
-    clktree_set_enabled(s->PERIPHCLK[STM32_CRC], IS_BIT_SET(new_value, RCC_AHB1ENR_CRCEN_BIT));
-
-    clktree_set_enabled(s->PERIPHCLK[STM32_GPIOK], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOKEN_BIT));
-    clktree_set_enabled(s->PERIPHCLK[STM32_GPIOJ], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOJEN_BIT));
-    clktree_set_enabled(s->PERIPHCLK[STM32_GPIOI], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOIEN_BIT));
-    clktree_set_enabled(s->PERIPHCLK[STM32_GPIOH], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOHEN_BIT));
-    clktree_set_enabled(s->PERIPHCLK[STM32_GPIOG], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOGEN_BIT));
-    clktree_set_enabled(s->PERIPHCLK[STM32_GPIOF], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOFEN_BIT));
-    clktree_set_enabled(s->PERIPHCLK[STM32_GPIOE], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOEEN_BIT));
-    clktree_set_enabled(s->PERIPHCLK[STM32_GPIOD], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIODEN_BIT));
-    clktree_set_enabled(s->PERIPHCLK[STM32_GPIOC], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOCEN_BIT));
-    clktree_set_enabled(s->PERIPHCLK[STM32_GPIOB], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOBEN_BIT));
-    clktree_set_enabled(s->PERIPHCLK[STM32_GPIOA], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOAEN_BIT));
+    clktree_set_enabled(&s->PERIPHCLK[STM32_DMA2], IS_BIT_SET(new_value, RCC_AHB1ENR_DMA2EN_BIT));
+    clktree_set_enabled(&s->PERIPHCLK[STM32_DMA1], IS_BIT_SET(new_value, RCC_AHB1ENR_DMA1EN_BIT));
+    clktree_set_enabled(&s->PERIPHCLK[STM32_CRC], IS_BIT_SET(new_value, RCC_AHB1ENR_CRCEN_BIT));
+    clktree_set_enabled(&s->PERIPHCLK[STM32_GPIOK], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOKEN_BIT));
+    clktree_set_enabled(&s->PERIPHCLK[STM32_GPIOJ], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOJEN_BIT));
+    clktree_set_enabled(&s->PERIPHCLK[STM32_GPIOI], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOIEN_BIT));
+    clktree_set_enabled(&s->PERIPHCLK[STM32_GPIOH], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOHEN_BIT));
+    clktree_set_enabled(&s->PERIPHCLK[STM32_GPIOG], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOGEN_BIT));
+    clktree_set_enabled(&s->PERIPHCLK[STM32_GPIOF], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOFEN_BIT));
+    clktree_set_enabled(&s->PERIPHCLK[STM32_GPIOE], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOEEN_BIT));
+    clktree_set_enabled(&s->PERIPHCLK[STM32_GPIOD], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIODEN_BIT));
+    clktree_set_enabled(&s->PERIPHCLK[STM32_GPIOC], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOCEN_BIT));
+    clktree_set_enabled(&s->PERIPHCLK[STM32_GPIOB], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOBEN_BIT));
+    clktree_set_enabled(&s->PERIPHCLK[STM32_GPIOA], IS_BIT_SET(new_value, RCC_AHB1ENR_GPIOAEN_BIT));
 
     s->RCC_AHB1ENR = new_value;
 
@@ -659,20 +640,20 @@ static void stm32_rcc_RCC_AHB1ENR_write(Stm32f2xxRcc *s, uint32_t new_value, boo
 
 static void stm32_rcc_RCC_AHB2ENR_write(Stm32f2xxRcc *s, uint32_t new_value, bool init)
 {
-    clktree_set_enabled(s->PERIPHCLK[STM32_DCMI_PERIPH],
+    clktree_set_enabled(&s->PERIPHCLK[STM32_DCMI_PERIPH],
                         IS_BIT_SET(new_value, RCC_AHB2ENR_DCMIEN_BIT));
-    clktree_set_enabled(s->PERIPHCLK[STM32_CRYP_PERIPH],
+    clktree_set_enabled(&s->PERIPHCLK[STM32_CRYP_PERIPH],
                         IS_BIT_SET(new_value, RCC_AHB2ENR_CRYPEN_BIT));
-    clktree_set_enabled(s->PERIPHCLK[STM32_HASH_PERIPH],
+    clktree_set_enabled(&s->PERIPHCLK[STM32_HASH_PERIPH],
                         IS_BIT_SET(new_value, RCC_AHB2ENR_HASHEN_BIT));
-    clktree_set_enabled(s->PERIPHCLK[STM32_RNG_PERIPH],
+    clktree_set_enabled(&s->PERIPHCLK[STM32_RNG_PERIPH],
                         IS_BIT_SET(new_value, RCC_AHB2ENR_RNGEN_BIT));
     s->RCC_AHB2ENR = new_value;
 }
 
 static void stm32_rcc_RCC_AHB3ENR_write(Stm32f2xxRcc *s, uint32_t new_value, bool init)
 {
-    clktree_set_enabled(s->PERIPHCLK[STM32_FSMC],
+    clktree_set_enabled(&s->PERIPHCLK[STM32_FSMC],
                         IS_BIT_SET(new_value, RCC_AHB3ENR_FSMCEN_BIT));
     s->RCC_AHB3ENR = new_value;
 }
@@ -739,7 +720,7 @@ static void stm32_rcc_RCC_APB1ENR_write(Stm32f2xxRcc *s, uint32_t new_value,
 
 static uint32_t stm32_rcc_RCC_BDCR_read(Stm32f2xxRcc *s)
 {
-    bool lseon = clktree_is_enabled(s->LSECLK);
+    bool lseon = clktree_is_enabled(&s->LSECLK);
 
     return GET_BIT_MASK(RCC_BDCR_LSERDY_BIT, lseon) |
     GET_BIT_MASK(RCC_BDCR_LSEON_BIT, lseon) | 0x100; /* XXX force LSE */
@@ -747,7 +728,7 @@ static uint32_t stm32_rcc_RCC_BDCR_read(Stm32f2xxRcc *s)
 
 static void stm32_rcc_RCC_BDCR_writeb0(Stm32f2xxRcc *s, uint8_t new_value, bool init)
 {
-    clktree_set_enabled(s->LSECLK, IS_BIT_SET(new_value, RCC_BDCR_LSEON_BIT));
+    clktree_set_enabled(&s->LSECLK, IS_BIT_SET(new_value, RCC_BDCR_LSEON_BIT));
     
     WARN_UNIMPLEMENTED(new_value, 1 << RCC_BDCR_LSEBYP_BIT, RCC_BDCR_RESET_VALUE);
 }
@@ -764,7 +745,7 @@ static void stm32_rcc_RCC_BDCR_write(Stm32f2xxRcc *s, uint32_t new_value, bool i
 /* Works the same way as stm32_rcc_RCC_CR_read */
 static uint32_t stm32_rcc_RCC_CSR_read(Stm32f2xxRcc *s)
 {
-    bool lseon = clktree_is_enabled(s->LSICLK);
+    bool lseon = clktree_is_enabled(&s->LSICLK);
 
     return GET_BIT_MASK(RCC_CSR_LSIRDY_BIT, lseon) |
     GET_BIT_MASK(RCC_CSR_LSION_BIT, lseon);
@@ -773,7 +754,7 @@ static uint32_t stm32_rcc_RCC_CSR_read(Stm32f2xxRcc *s)
 /* Works the same way as stm32_rcc_RCC_CR_write */
 static void stm32_rcc_RCC_CSR_write(Stm32f2xxRcc *s, uint32_t new_value, bool init)
 {
-    clktree_set_enabled(s->LSICLK, IS_BIT_SET(new_value, RCC_CSR_LSION_BIT));
+    clktree_set_enabled(&s->LSICLK, IS_BIT_SET(new_value, RCC_CSR_LSION_BIT));
 }
 
 
@@ -983,7 +964,7 @@ static void stm32_rcc_hclk_upd_irq_handler(void *opaque, int n, int level)
     uint32_t hclk_freq = 0;
     // uint32_t ext_ref_freq = 0;
     
-    hclk_freq = clktree_get_output_freq(s->HCLK);
+    hclk_freq = clktree_get_output_freq(&s->HCLK);
 
     /* Only update the scales if the frequency is not zero. */
     if (hclk_freq > 0) {
@@ -1020,7 +1001,7 @@ static void stm32_rcc_realize(DeviceState *dev, Error **errp)
      * indexes will be used).
      */
     for(i = 0; i < STM32_PERIPH_COUNT; i++) {
-        s->PERIPHCLK[i] = NULL;
+        s->PERIPHCLK[i].is_initialized = false;
     }
 
     /* Initialize clocks */
@@ -1028,123 +1009,95 @@ static void stm32_rcc_realize(DeviceState *dev, Error **errp)
      * a disabled oscillator.  Enabling the clock represents
      * turning the clock on.
      */
-    s->HSICLK = clktree_create_src_clk("HSI", HSI_FREQ, false);
-    s->LSICLK = clktree_create_src_clk("LSI", LSI_FREQ, false);
-    s->HSECLK = clktree_create_src_clk("HSE", s->osc_freq, false);
-    s->LSECLK = clktree_create_src_clk("LSE", s->osc32_freq, false);
+    clktree_create_src_clk(&s->HSICLK, "HSI", HSI_FREQ, false);
+    clktree_create_src_clk(&s->LSICLK, "LSI", LSI_FREQ, false);
+    clktree_create_src_clk(&s->HSECLK, "HSE", s->osc_freq, false);
+    clktree_create_src_clk(&s->LSECLK, "LSE", s->osc32_freq, false);
 
     // Moved into PERIPHCLK so it can be queried
     // s->IWDGCLK = clktree_create_clk("IWDGCLK", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0,
     //                                 s->LSICLK, NULL);
-    s->RTCCLK = clktree_create_clk("RTCCLK", 1, 1, false, CLKTREE_NO_MAX_FREQ,
-                                   CLKTREE_NO_INPUT, s->LSECLK, s->LSICLK, s->HSECLK, NULL);
+    clktree_create_clk(&s->RTCCLK, "RTCCLK", 1, 1, false, CLKTREE_NO_MAX_FREQ,
+                                   CLKTREE_NO_INPUT, &s->LSECLK, &s->LSICLK, &s->HSECLK, NULL);
 
-    s->PLLM = clktree_create_clk("PLLM", 1, 16, true, CLKTREE_NO_MAX_FREQ, 0, s->HSICLK,
-                                 s->HSECLK, NULL);
-    s->PLLCLK = clktree_create_clk("PLLCLK", 1, 2, false, 120000000, 0, s->PLLM, NULL);
-    s->PLL48CLK = clktree_create_clk("PLL48CLK", 1, 1, false, 48000000, 0, s->PLLM, NULL);
+    clktree_create_clk(&s->PLLM, "PLLM", 1, 16, true, CLKTREE_NO_MAX_FREQ, 0, &s->HSICLK,
+                                 &s->HSECLK, NULL);
+    clktree_create_clk(&s->PLLCLK, "PLLCLK", 1, 2, false, 120000000, 0, &s->PLLM, NULL);
+    clktree_create_clk(&s->PLL48CLK, "PLL48CLK", 1, 1, false, 48000000, 0, &s->PLLM, NULL);
 
-    s->PLLI2SM = clktree_create_clk("PLLI2SM", 1, 16, true, CLKTREE_NO_MAX_FREQ, 0, s->PLLM, NULL);
-    s->PLLI2SCLK = clktree_create_clk("PLLI2SCLK", 1, 2, false, 120000000, 0, s->PLLI2SM, NULL);
+    clktree_create_clk(&s->PLLI2SM, "PLLI2SM", 1, 16, true, CLKTREE_NO_MAX_FREQ, 0, &s->PLLM, NULL);
+    clktree_create_clk(&s->PLLI2SCLK, "PLLI2SCLK", 1, 2, false, 120000000, 0, &s->PLLI2SM, NULL);
 
-    s->SYSCLK = clktree_create_clk("SYSCLK", 1, 1, true, 168000000, CLKTREE_NO_INPUT,
-                                   s->HSICLK, s->HSECLK, s->PLLCLK, NULL);
+    clktree_create_clk(&s->SYSCLK, "SYSCLK", 1, 1, true, 168000000, CLKTREE_NO_INPUT,
+                                   &s->HSICLK, &s->HSECLK, &s->PLLCLK, NULL);
 
     // HCLK: to AHB bus, core memory and DMA
-    s->HCLK = clktree_create_clk("HCLK", 0, 1, true, 168000000, 0, s->SYSCLK, NULL);
-    clktree_adduser(s->HCLK, hclk_upd_irq[0]);
+    clktree_create_clk(&s->HCLK, "HCLK", 0, 1, true, 168000000, 0, &s->SYSCLK, NULL);
+    clktree_adduser(&s->HCLK, hclk_upd_irq[0]);
 
     // Clock source for APB1 peripherals:
-    s->PCLK1 = clktree_create_clk("PCLK1", 0, 1, true, 30000000, 0, s->HCLK, NULL);
+
+    clktree_create_clk(&s->PCLK1, "PCLK1", 0, 1, true, 30000000, 0, &s->HCLK, NULL);
 
     // Clock source for APB2 peripherals:
-    s->PCLK2 = clktree_create_clk("PCLK2", 0, 1, true, 60000000, 0, s->HCLK, NULL);
+    clktree_create_clk(&s->PCLK2, "PCLK2", 0, 1, true, 60000000, 0, &s->HCLK, NULL);
 
     /* Peripheral clocks */
-    s->PERIPHCLK[STM32_GPIOA] =
-        clktree_create_clk("GPIOA", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
-    s->PERIPHCLK[STM32_GPIOB] =
-        clktree_create_clk("GPIOB", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
-    s->PERIPHCLK[STM32_GPIOC] =
-        clktree_create_clk("GPIOC", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
-    s->PERIPHCLK[STM32_GPIOD] =
-        clktree_create_clk("GPIOD", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
-    s->PERIPHCLK[STM32_GPIOE] =
-        clktree_create_clk("GPIOE", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
-    s->PERIPHCLK[STM32_GPIOF] =
-        clktree_create_clk("GPIOF", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
-    s->PERIPHCLK[STM32_GPIOG] =
-        clktree_create_clk("GPIOG", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
-    s->PERIPHCLK[STM32_GPIOH] =
-        clktree_create_clk("GPIOH", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
-    s->PERIPHCLK[STM32_GPIOI] =
-        clktree_create_clk("GPIOI", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
-    s->PERIPHCLK[STM32_GPIOJ] =
-        clktree_create_clk("GPIOJ", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
-    s->PERIPHCLK[STM32_GPIOK] =
-        clktree_create_clk("GPIOK", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_GPIOA], "GPIOA", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_GPIOB], "GPIOB", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_GPIOC], "GPIOC", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_GPIOD], "GPIOD", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_GPIOE], "GPIOE", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_GPIOF], "GPIOF", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_GPIOG], "GPIOG", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_GPIOH], "GPIOH", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_GPIOI], "GPIOI", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_GPIOJ], "GPIOJ", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_GPIOK], "GPIOK", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
 
-    s->PERIPHCLK[STM32_CRC] =
-        clktree_create_clk("CRC", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_CRC], "CRC", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
 
-    s->PERIPHCLK[STM32_DMA1] =
-        clktree_create_clk("DMA1", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
-    s->PERIPHCLK[STM32_DMA2] =
-        clktree_create_clk("DMA2", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_DMA1], "DMA1", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_DMA2], "DMA2", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
     
-    s->PERIPHCLK[STM32_SYSCFG] =
-        clktree_create_clk("SYSCFG", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK2, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_SYSCFG], "SYSCFG", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK2, NULL);
 
-    s->PERIPHCLK[STM32_UART1] =
-        clktree_create_clk("UART1", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK2, NULL);
-    s->PERIPHCLK[STM32_UART2] =
-        clktree_create_clk("UART2", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK1, NULL);
-    s->PERIPHCLK[STM32_UART3] =
-        clktree_create_clk("UART3", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK1, NULL);
-    s->PERIPHCLK[STM32_UART4] =
-        clktree_create_clk("UART4", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK1, NULL);
-    s->PERIPHCLK[STM32_UART5] =
-        clktree_create_clk("UART5", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK1, NULL);
-    s->PERIPHCLK[STM32_UART6] =
-        clktree_create_clk("UART6", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK2, NULL);
-    s->PERIPHCLK[STM32_UART7] =
-        clktree_create_clk("UART7", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK1, NULL);
-    s->PERIPHCLK[STM32_UART8] =
-        clktree_create_clk("UART8", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK1, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_UART1], "UART1", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK2, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_UART2], "UART2", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK1, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_UART3], "UART3", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK1, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_UART4], "UART4", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK1, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_UART5], "UART5", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK1, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_UART6], "UART6", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK2, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_UART7], "UART7", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK1, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_UART8], "UART8", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK1, NULL);
     
     
     // Timers run at 2x the APB speed 
-    s->PERIPHCLK[STM32_TIM1]  = clktree_create_clk("TIM1", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK2, NULL);
-    s->PERIPHCLK[STM32_TIM2]  = clktree_create_clk("TIM2", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK1, NULL);
-    s->PERIPHCLK[STM32_TIM3]  = clktree_create_clk("TIM3", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK1, NULL);
-    s->PERIPHCLK[STM32_TIM4]  = clktree_create_clk("TIM4", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK1, NULL);
-    s->PERIPHCLK[STM32_TIM5]  = clktree_create_clk("TIM5", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK1, NULL);
-    s->PERIPHCLK[STM32_TIM6]  = clktree_create_clk("TIM6", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK1, NULL);
-    s->PERIPHCLK[STM32_TIM7]  = clktree_create_clk("TIM7", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK1, NULL);
-    s->PERIPHCLK[STM32_TIM8]  = clktree_create_clk("TIM8", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK2, NULL);
-    s->PERIPHCLK[STM32_TIM9]  = clktree_create_clk("TIM9", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK2, NULL);
-    s->PERIPHCLK[STM32_TIM10] = clktree_create_clk("TIM10",2, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK2, NULL);
-    s->PERIPHCLK[STM32_TIM11] = clktree_create_clk("TIM11",2, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK2, NULL);
-    s->PERIPHCLK[STM32_TIM12] = clktree_create_clk("TIM12",2, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK1, NULL);
-    s->PERIPHCLK[STM32_TIM13] = clktree_create_clk("TIM13",2, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK1, NULL);
-    s->PERIPHCLK[STM32_TIM14] = clktree_create_clk("TIM14",2, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->PCLK1, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_TIM1], "TIM1", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK2, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_TIM2], "TIM2", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK1, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_TIM3], "TIM3", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK1, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_TIM4], "TIM4", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK1, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_TIM5], "TIM5", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK1, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_TIM6], "TIM6", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK1, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_TIM7], "TIM7", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK1, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_TIM8], "TIM8", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK2, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_TIM9], "TIM9", 2, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK2, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_TIM10], "TIM10",2, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK2, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_TIM11], "TIM11",2, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK2, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_TIM12], "TIM12",2, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK1, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_TIM13], "TIM13",2, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK1, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_TIM14], "TIM14",2, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->PCLK1, NULL);
 
 
-    s->PERIPHCLK[STM32_IWDG] = clktree_create_clk("IWDGCLK", 1, 1, true, CLKTREE_NO_MAX_FREQ, 0,
-                                    s->LSICLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_IWDG], "IWDGCLK", 1, 1, true, CLKTREE_NO_MAX_FREQ, 0,
+                                    &s->LSICLK, NULL);
 
-    s->PERIPHCLK[STM32_DCMI_PERIPH] =
-        clktree_create_clk("DCMI", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
-    s->PERIPHCLK[STM32_CRYP_PERIPH] =
-        clktree_create_clk("CRYP", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
-    s->PERIPHCLK[STM32_HASH_PERIPH] =
-        clktree_create_clk("HASH", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
-    s->PERIPHCLK[STM32_RNG_PERIPH] =
-        clktree_create_clk("RNG", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_DCMI_PERIPH], "DCMI", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_CRYP_PERIPH], "CRYP", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_HASH_PERIPH], "HASH", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
+    clktree_create_clk(&s->PERIPHCLK[STM32_RNG_PERIPH], "RNG", 1, 1, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
 
-    s->PERIPHCLK[STM32_FSMC] =
-        clktree_create_clk("FSMC", 1, 2, false, CLKTREE_NO_MAX_FREQ, 0, s->HCLK, NULL);
-
+    clktree_create_clk(&s->PERIPHCLK[STM32_FSMC], "FSMC", 1, 2, false, CLKTREE_NO_MAX_FREQ, 0, &s->HCLK, NULL);
     // Reset IRQs:
     qdev_init_gpio_out_named(DEVICE(dev),s->reset,"reset",STM32_PERIPH_COUNT);
 }
@@ -1173,6 +1126,68 @@ static Property stm32_rcc_properties[] = {
     DEFINE_PROP_END_OF_LIST()
 };
 
+static int rcc_pre_save(void *opaque) {
+    DEBUG_TAKE(opaque,0);
+    return 0;
+}
+
+#define DEBUG_CHK_CLK(name) \
+    DEBUG_CHECK(name.enabled); \
+    DEBUG_CHECK(name.input_freq); \
+    DEBUG_CHECK(name.output_freq); \
+    DEBUG_CHECK(name.max_output_freq); \
+    DEBUG_CHECK(name.multiplier); \
+    DEBUG_CHECK(name.divisor); \
+    DEBUG_CHECK(name.user_count); \
+    DEBUG_CHECK(name.output_count); \
+    DEBUG_CHECK(name.input_count); \
+    DEBUG_CHECK(name.selected_input); 
+
+static int rcc_post_load(void *opaque, int version) {
+    DEBUG_CAST_ONLY(Stm32f2xxRcc *s = STM32F2XX_RCC(opaque));
+    DEBUG_INDEX(0);
+    for (int i=0; i<STM32_PERIPH_COUNT; i++) {
+        DEBUG_CHK_CLK(PERIPHCLK[i]);
+    }
+    DEBUG_CHK_CLK(HSICLK);
+    DEBUG_CHK_CLK(HSECLK);
+    DEBUG_CHK_CLK(LSECLK);
+    DEBUG_CHK_CLK(LSICLK);
+    DEBUG_CHK_CLK(SYSCLK);
+    DEBUG_CHK_CLK(IWDGCLK);
+    DEBUG_CHK_CLK(RTCCLK);
+    DEBUG_CHK_CLK(PLLM);
+    DEBUG_CHK_CLK(PLLCLK);
+    DEBUG_CHK_CLK(PLL48CLK);
+    DEBUG_CHK_CLK(PLLI2SM);
+    DEBUG_CHK_CLK(PLLI2SCLK);
+    DEBUG_CHK_CLK(HCLK);
+    DEBUG_CHK_CLK(PCLK1);
+    DEBUG_CHK_CLK(PCLK2);
+    DEBUG_CHECK(osc_freq);
+    DEBUG_CHECK(osc32_freq);
+    DEBUG_CHECK(RCC_CIR);
+    DEBUG_CHECK(RCC_APB1ENR);
+    DEBUG_CHECK(RCC_APB2ENR);
+    DEBUG_CHECK(RCC_CFGR_PPRE1);
+    DEBUG_CHECK(RCC_CFGR_PPRE2);
+    DEBUG_CHECK(RCC_CFGR_HPRE);
+    DEBUG_CHECK(RCC_AHB1ENR);
+    DEBUG_CHECK(RCC_AHB2ENR);
+    DEBUG_CHECK(RCC_AHB3ENR);
+    DEBUG_CHECK(RCC_CFGR_SW);
+    DEBUG_CHECK(RCC_PLLCFGR);
+    DEBUG_CHECK(RCC_PLLI2SCFGR);
+    DEBUG_CHECK(RCC_PLLCFGR_PLLM);
+    DEBUG_CHECK(RCC_PLLCFGR_PLLP);
+    DEBUG_CHECK(RCC_PLLCFGR_PLLSRC);
+    DEBUG_CHECK(RCC_PLLCFGR_PLLN);
+    DEBUG_CHECK(RCC_PLLI2SCFGR_PLLR);
+    DEBUG_CHECK(RCC_PLLI2SCFGR_PLLQ);
+    DEBUG_CHECK(RCC_PLLI2SCFGR_PLLN);
+    return 0;
+}
+
 static const VMStateDescription vmstate_stm32f2xx_rcc_clk = {
     .name = TYPE_STM32F2XX_RCC "-clk",
     .version_id = 1,
@@ -1184,10 +1199,10 @@ static const VMStateDescription vmstate_stm32f2xx_rcc_clk = {
         VMSTATE_UINT32(max_output_freq,struct Clk),
         VMSTATE_UINT16(multiplier,struct Clk),
         VMSTATE_UINT16(divisor,struct Clk),
-        VMSTATE_UINT32(user_count,struct Clk),
-        VMSTATE_UINT32(output_count,struct Clk),
-        VMSTATE_UINT32(input_count,struct Clk),
-        VMSTATE_INT32(selected_input,struct Clk),
+        VMSTATE_UINT8(user_count,struct Clk),
+        VMSTATE_UINT8(output_count,struct Clk),
+        VMSTATE_UINT8(input_count,struct Clk),
+        VMSTATE_INT16(selected_input,struct Clk),
         VMSTATE_END_OF_LIST()
     }
 };
@@ -1196,25 +1211,27 @@ static const VMStateDescription vmstate_stm32f2xx_rcc = {
     .name = TYPE_STM32F2XX_RCC,
     .version_id = 1,
     .minimum_version_id = 1,
+    .pre_save = rcc_pre_save,
+    .post_load = rcc_post_load,
     .fields = (VMStateField[]) {
         VMSTATE_UINT32(osc_freq, Stm32f2xxRcc),
         VMSTATE_UINT32(osc32_freq, Stm32f2xxRcc),
-        VMSTATE_STRUCT_ARRAY(PERIPHCLK, Stm32f2xxRcc, STM32_PERIPH_COUNT, 1, vmstate_stm32f2xx_rcc_clk,Clk),
-        VMSTATE_STRUCT(HSICLK,Stm32f2xxRcc,1, vmstate_stm32f2xx_rcc_clk,Clk),
-        VMSTATE_STRUCT(HSECLK,Stm32f2xxRcc,1, vmstate_stm32f2xx_rcc_clk,Clk),
-        VMSTATE_STRUCT(LSECLK,Stm32f2xxRcc,1, vmstate_stm32f2xx_rcc_clk,Clk),
-        VMSTATE_STRUCT(LSICLK,Stm32f2xxRcc,1, vmstate_stm32f2xx_rcc_clk,Clk),
-        VMSTATE_STRUCT(SYSCLK,Stm32f2xxRcc,1, vmstate_stm32f2xx_rcc_clk,Clk),
-        VMSTATE_STRUCT(IWDGCLK,Stm32f2xxRcc,1, vmstate_stm32f2xx_rcc_clk,Clk),
-        VMSTATE_STRUCT(RTCCLK,Stm32f2xxRcc,1, vmstate_stm32f2xx_rcc_clk,Clk),
-        VMSTATE_STRUCT(PLLM,Stm32f2xxRcc,1, vmstate_stm32f2xx_rcc_clk,Clk),
-        VMSTATE_STRUCT(PLLCLK,Stm32f2xxRcc,1, vmstate_stm32f2xx_rcc_clk,Clk),
-        VMSTATE_STRUCT(PLL48CLK,Stm32f2xxRcc,1, vmstate_stm32f2xx_rcc_clk,Clk),
-        VMSTATE_STRUCT(PLLI2SM,Stm32f2xxRcc,1, vmstate_stm32f2xx_rcc_clk,Clk),
-        VMSTATE_STRUCT(PLLI2SCLK,Stm32f2xxRcc,1, vmstate_stm32f2xx_rcc_clk,Clk),
-        VMSTATE_STRUCT(HCLK,Stm32f2xxRcc,1, vmstate_stm32f2xx_rcc_clk,Clk),
-        VMSTATE_STRUCT(PCLK1,Stm32f2xxRcc,1, vmstate_stm32f2xx_rcc_clk,Clk),
-        VMSTATE_STRUCT(PCLK2,Stm32f2xxRcc,1, vmstate_stm32f2xx_rcc_clk,Clk),
+        VMSTATE_STRUCT_ARRAY(PERIPHCLK, Stm32f2xxRcc, STM32_PERIPH_COUNT, 1, vmstate_stm32f2xx_rcc_clk, Clk_t),
+        VMSTATE_STRUCT(HSICLK,Stm32f2xxRcc, 1, vmstate_stm32f2xx_rcc_clk, Clk_t),
+        VMSTATE_STRUCT(HSECLK,Stm32f2xxRcc, 1, vmstate_stm32f2xx_rcc_clk, Clk_t),
+        VMSTATE_STRUCT(LSECLK,Stm32f2xxRcc, 1, vmstate_stm32f2xx_rcc_clk, Clk_t),
+        VMSTATE_STRUCT(LSICLK,Stm32f2xxRcc, 1, vmstate_stm32f2xx_rcc_clk, Clk_t),
+        VMSTATE_STRUCT(SYSCLK,Stm32f2xxRcc, 1, vmstate_stm32f2xx_rcc_clk, Clk_t),
+        VMSTATE_STRUCT(IWDGCLK,Stm32f2xxRcc, 1, vmstate_stm32f2xx_rcc_clk, Clk_t),
+        VMSTATE_STRUCT(RTCCLK,Stm32f2xxRcc, 1, vmstate_stm32f2xx_rcc_clk, Clk_t),
+        VMSTATE_STRUCT(PLLM,Stm32f2xxRcc, 1, vmstate_stm32f2xx_rcc_clk, Clk_t),
+        VMSTATE_STRUCT(PLLCLK,Stm32f2xxRcc, 1, vmstate_stm32f2xx_rcc_clk, Clk_t),
+        VMSTATE_STRUCT(PLL48CLK,Stm32f2xxRcc, 1, vmstate_stm32f2xx_rcc_clk, Clk_t),
+        VMSTATE_STRUCT(PLLI2SM,Stm32f2xxRcc, 1, vmstate_stm32f2xx_rcc_clk, Clk_t),
+        VMSTATE_STRUCT(PLLI2SCLK,Stm32f2xxRcc, 1, vmstate_stm32f2xx_rcc_clk, Clk_t),
+        VMSTATE_STRUCT(HCLK,Stm32f2xxRcc, 1, vmstate_stm32f2xx_rcc_clk, Clk_t),
+        VMSTATE_STRUCT(PCLK1,Stm32f2xxRcc, 1, vmstate_stm32f2xx_rcc_clk, Clk_t),
+        VMSTATE_STRUCT(PCLK2,Stm32f2xxRcc, 1, vmstate_stm32f2xx_rcc_clk, Clk_t),
         VMSTATE_UINT32(RCC_CIR,Stm32f2xxRcc),
         VMSTATE_UINT32(RCC_APB1ENR,Stm32f2xxRcc),
         VMSTATE_UINT32(RCC_APB2ENR,Stm32f2xxRcc),

--- a/hw/arm/prusa/stm32f407/stm32f2xx_rcc.h
+++ b/hw/arm/prusa/stm32f407/stm32f2xx_rcc.h
@@ -27,6 +27,7 @@
 #include "qom/object.h"
 #include "qemu-common.h"
 #include "stm32_clktree.h"
+#include "stm32_clk_type.h"
 #include "stm32_rcc.h"
 #include "stm32.h"
 
@@ -38,7 +39,7 @@ typedef struct Stm32f2xxRcc {
     STM32_RCC_COMMON
     
     /* Additional clocks */
-    Clk HSICLK,
+    Clk_t HSICLK,
     HSECLK,
     LSECLK,
     LSICLK,

--- a/hw/arm/prusa/stm32f407/stm32f2xx_rtc.c
+++ b/hw/arm/prusa/stm32f407/stm32f2xx_rtc.c
@@ -26,6 +26,7 @@
 #include "stm32f2xx_rtc.h"
 #include <sys/time.h>
 #include "qemu-common.h"
+#include "migration/vmstate.h"
 #include "hw/sysbus.h"
 #include "qemu/timer.h"
 #include "qemu/log.h"
@@ -601,18 +602,26 @@ f2xx_rtc_init(Object *obj)
     s->wu_timer = timer_new_ns(QEMU_CLOCK_REALTIME, f2xx_wu_timer, s);
 }
 
-// static Property f2xx_rtc_properties[] = {
-//     DEFINE_PROP_END_OF_LIST(),
-// };
+static const VMStateDescription vmstate_stm32f2xx_rtc = {
+    .name = TYPE_STM32F2XX_RTC,
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .fields = (VMStateField[]) {
+        VMSTATE_TIMER_PTR(timer,f2xx_rtc),
+        VMSTATE_TIMER_PTR(wu_timer,f2xx_rtc),
+        VMSTATE_INT64(host_to_target_offset_us,f2xx_rtc),
+        VMSTATE_INT64(ticks,f2xx_rtc),
+        VMSTATE_UINT32_ARRAY(regs,f2xx_rtc,R_RTC_MAX),
+        VMSTATE_INT32(wp_count,f2xx_rtc),
+        VMSTATE_END_OF_LIST()
+    }
+};
 
 static void
 f2xx_rtc_class_init(ObjectClass *klass, void *data)
 {
     DeviceClass *dc = DEVICE_CLASS(klass);
-    // SysBusDeviceClass *sc = SYS_BUS_DEVICE_CLASS(klass);
-    // sc->init = f2xx_rtc_init;
-    //TODO: fix this: dc->no_user = 1;
-    //dc->props = f2xx_rtc_properties;
+    dc->vmsd = &vmstate_stm32f2xx_rtc;
     dc->reset = f2xx_rtc_reset;
 }
 

--- a/hw/arm/prusa/stm32f407/stm32f2xx_tim.c
+++ b/hw/arm/prusa/stm32f407/stm32f2xx_tim.c
@@ -24,6 +24,7 @@
  * QEMU stm32f2xx TIM emulation
  */
 #include "stm32f2xx_tim.h"
+#include "migration/vmstate.h"
 #include "qemu-common.h"
 #include "qemu/log.h"
 #include "qemu/timer.h"
@@ -408,15 +409,25 @@ f2xx_tim_init(Object *obj)
     qdev_init_gpio_out_named(DEVICE(dev), s->pwm_enable, "pwm_enable", 4);
 }
 
-// static Property f2xx_tim_properties[] = {
-//     DEFINE_PROP_END_OF_LIST(),
-// };
-
+static const VMStateDescription vmstate_stm32f2xx_tim = {
+    .name = TYPE_STM32F4XX_TIMER,
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .fields = (VMStateField[]) {
+        VMSTATE_TIMER_PTR(timer,f2xx_tim),
+        VMSTATE_TIMER_PTR(pwmtimer,f2xx_tim),
+        VMSTATE_UINT32_ARRAY(regs,f2xx_tim,R_TIM_MAX),
+        VMSTATE_UINT8(id,f2xx_tim),
+        VMSTATE_INT64(count_timebase,f2xx_tim),
+        VMSTATE_INT32(periph,f2xx_tim),
+        VMSTATE_END_OF_LIST()
+    }
+};
 static void
 f2xx_tim_class_init(ObjectClass *klass, void *data)
 {
     DeviceClass *dc = DEVICE_CLASS(klass);
-    //TODO: fix this: dc->no_user = 1;
+    dc->vmsd = &vmstate_stm32f2xx_tim;
     dc->reset = f2xx_tim_reset;
 
 }

--- a/hw/arm/prusa/stm32f407/stm32f2xx_tim.c
+++ b/hw/arm/prusa/stm32f407/stm32f2xx_tim.c
@@ -415,7 +415,6 @@ static const VMStateDescription vmstate_stm32f2xx_tim = {
     .minimum_version_id = 1,
     .fields = (VMStateField[]) {
         VMSTATE_TIMER_PTR(timer,f2xx_tim),
-        VMSTATE_TIMER_PTR(pwmtimer,f2xx_tim),
         VMSTATE_UINT32_ARRAY(regs,f2xx_tim,R_TIM_MAX),
         VMSTATE_UINT8(id,f2xx_tim),
         VMSTATE_INT64(count_timebase,f2xx_tim),

--- a/hw/arm/prusa/stm32f407/stm32f2xx_tim.h
+++ b/hw/arm/prusa/stm32f407/stm32f2xx_tim.h
@@ -33,7 +33,7 @@
 #include "hw/sysbus.h"
 #include "stm32.h"
 
-#define SHORT_REG_32(name,used) struct{ uint32_t name :used; uint32_t :32-used; } __attribute__ ((__packed__))
+#define SHORT_REG_32(name,used) struct{ uint32_t name :used; uint32_t :32-used; } QEMU_PACKED 
 
 #define R_TIM_MAX    (0x54 / 4)
 
@@ -61,7 +61,7 @@ struct f2xx_tim {
                 uint32_t ARPE :1;
                 uint32_t CKD :2;
                 uint32_t :22; // unused.
-            } __attribute__ ((__packed__)) CR1;
+            } QEMU_PACKED  CR1;
             struct {
                 uint32_t CCPC :1;
                 uint32_t _reserved :1;
@@ -77,7 +77,7 @@ struct f2xx_tim {
                 uint32_t OIS3N :1;
                 uint32_t OIS4 :1;
                 uint32_t :32-15; // unused.
-            } __attribute__ ((__packed__)) CR2;         
+            } QEMU_PACKED  CR2;         
             struct {
                 uint32_t SMS :3;
                 uint32_t _reserved :1;
@@ -88,7 +88,7 @@ struct f2xx_tim {
                 uint32_t ECE :1;
                 uint32_t ETP :1;
                 uint32_t :32-16; // unused.
-            } __attribute__ ((__packed__)) SMCR;
+            } QEMU_PACKED  SMCR;
             struct {
                 uint32_t UIE :1;
                 uint32_t CC1IE:1;
@@ -106,7 +106,7 @@ struct f2xx_tim {
                 uint32_t COMDE:1;
                 uint32_t TDE:1;
                 uint32_t :17;
-            } __attribute__ ((__packed__))DIER;
+            } QEMU_PACKED DIER;
             struct {
                 uint32_t UIF:1;
                 uint32_t CC1IF:1;
@@ -122,7 +122,7 @@ struct f2xx_tim {
                 uint32_t CC3OF:1;
                 uint32_t CC4OF:1;
                 uint32_t :32-13;
-            } __attribute__ ((__packed__))SR;
+            } QEMU_PACKED SR;
             struct {
                 uint32_t UG:1;
                 uint32_t CC1G:1;
@@ -133,7 +133,7 @@ struct f2xx_tim {
                 uint32_t TG:1;
                 uint32_t BG:1;
                 uint32_t :32-8;
-            } __attribute__ ((__packed__))EGR;
+            } QEMU_PACKED EGR;
             struct {
                 uint32_t CC1S :2;
                 uint32_t OC1FE :1;
@@ -146,7 +146,7 @@ struct f2xx_tim {
                 uint32_t OC2M :3;
                 uint32_t OC2CE :1;
                 uint32_t :32-16;
-            } __attribute__ ((__packed__))CCMR1; // N.B this is only the OC mode, not IC
+            } QEMU_PACKED CCMR1; // N.B this is only the OC mode, not IC
             struct {
                 uint32_t CC3S :2;
                 uint32_t OC3FE :1;
@@ -159,7 +159,7 @@ struct f2xx_tim {
                 uint32_t OC4M :3;
                 uint32_t OC4CE :1;
                 uint32_t :32-16;
-            } __attribute__ ((__packed__))CCMR2;
+            } QEMU_PACKED CCMR2;
             struct {
                 uint32_t CC1E :1;
                 uint32_t CC1P :1;
@@ -176,7 +176,7 @@ struct f2xx_tim {
                 uint32_t CC4E :1;
                 uint32_t CC4P :1;
                 uint32_t :32-14;                
-            } __attribute__ ((__packed__)) CCER;
+            } QEMU_PACKED  CCER;
             SHORT_REG_32(CNT, 16);
             SHORT_REG_32(PSC, 16);
             SHORT_REG_32(ARR, 16);
@@ -195,13 +195,13 @@ struct f2xx_tim {
                 uint32_t AOE :1;
                 uint32_t MOE :1;
                 uint32_t :32-16;
-            } __attribute__ ((__packed__)) BDTR;
+            } QEMU_PACKED  BDTR;
             struct {
                 uint32_t DBA:5;
                 uint32_t _reserved :3;
                 uint32_t DBL :5;
                 uint32_t :19;
-            } __attribute__ ((__packed__))DCR;
+            } QEMU_PACKED DCR;
             uint32_t DMAR;
             SHORT_REG_32(RMP,2) OR;
         } defs;

--- a/hw/arm/prusa/stm32f407/stm32f407_soc.c
+++ b/hw/arm/prusa/stm32f407/stm32f407_soc.c
@@ -266,7 +266,6 @@ static void stm32f407_soc_realize(DeviceState *dev_soc, Error **errp)
         s->usart[i].periph = STM32_UART1+i;
         s->usart[i].stm32_rcc = (Stm32Rcc*)&s->rcc;
         qdev_prop_set_chr(dev, "chardev", serial_hd(i));
-        qdev_prop_set_int32(dev, "index",i+1); // Set to STM index, not 0-based
         if (!sysbus_realize(SYS_BUS_DEVICE(&s->usart[i]), errp)) {
             return;
         }

--- a/hw/arm/prusa/stm32f407/stm32f4xx_adc.c
+++ b/hw/arm/prusa/stm32f407/stm32f4xx_adc.c
@@ -363,6 +363,10 @@ static const VMStateDescription vmstate_stm32f4xx_adc = {
         VMSTATE_UINT32(adc_jsqr, STM32F4XXADCState),
         VMSTATE_UINT32_ARRAY(adc_jdr, STM32F4XXADCState, 4),
         VMSTATE_UINT32(adc_dr, STM32F4XXADCState),
+        VMSTATE_INT32_ARRAY(adc_data,STM32F4XXADCState, ADC_NUM_REG_CHANNELS),
+        VMSTATE_UINT8_ARRAY(adc_sequence,STM32F4XXADCState, ADC_NUM_REG_CHANNELS),
+        VMSTATE_UINT8(adc_sequence_position,STM32F4XXADCState),
+        VMSTATE_INT32(id,STM32F4XXADCState),
         VMSTATE_END_OF_LIST()
     }
 };

--- a/hw/arm/prusa/stm32f407/stm32f4xx_eth.c
+++ b/hw/arm/prusa/stm32f407/stm32f4xx_eth.c
@@ -189,31 +189,6 @@ struct Stm32F4xx_Eth {
     bool is_connected;
 };
 
-// static const VMStateDescription vmstate_rxtx_stats = {
-//     .name = "stm32f4xx_eth_stats",
-//     .version_id = 1,
-//     .minimum_version_id = 1,
-//     .fields = (VMStateField[]) {
-//         VMSTATE_UINT64(rx_bytes, RxTxStats),
-//         VMSTATE_UINT64(tx_bytes, RxTxStats),
-//         VMSTATE_UINT64(rx, RxTxStats),
-//         VMSTATE_UINT64(rx_bcast, RxTxStats),
-//         VMSTATE_UINT64(rx_mcast, RxTxStats),
-//         VMSTATE_END_OF_LIST()
-//     }
-// };
-
-// static const VMStateDescription vmstate_xgmac = {
-//     .name = "xgmac",
-//     .version_id = 1,
-//     .minimum_version_id = 1,
-//     .fields = (VMStateField[]) {
-//         VMSTATE_STRUCT(stats, Stm32F4xx_Eth, 0, vmstate_rxtx_stats, RxTxStats),
-//         VMSTATE_UINT32_ARRAY(regs, Stm32F4xx_Eth, R_MAX),
-//         VMSTATE_END_OF_LIST()
-//     }
-// };
-
 static void stm32f4xx_eth_read_desc(Stm32F4xx_Eth *s, struct desc *d, int rx)
 {
     uint32_t addr = rx ? s->regs[DMA_CUR_RX_DESC_ADDR] :
@@ -520,12 +495,39 @@ static Property stm32f4xx_eth_properties[] = {
     DEFINE_PROP_END_OF_LIST(),
 };
 
+static const VMStateDescription vmstate_rxtx_stats = {
+    .name = "stm32f4xx_eth_stats",
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .fields = (VMStateField[]) {
+        VMSTATE_UINT64(rx_bytes, RxTxStats),
+        VMSTATE_UINT64(tx_bytes, RxTxStats),
+        VMSTATE_UINT64(rx, RxTxStats),
+        VMSTATE_UINT64(rx_bcast, RxTxStats),
+        VMSTATE_UINT64(rx_mcast, RxTxStats),
+        VMSTATE_END_OF_LIST()
+    }
+};
+
+static const VMStateDescription vmstate_stm32f4xx_eth = {
+    .name = TYPE_STM32F4XXETH,
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .fields = (VMStateField[]) {
+        VMSTATE_STRUCT(stats, Stm32F4xx_Eth, 0, vmstate_rxtx_stats, RxTxStats),
+        VMSTATE_UINT32_ARRAY(regs, Stm32F4xx_Eth, R_MAX),
+        VMSTATE_UINT16_ARRAY(mii,Stm32F4xx_Eth, 32),
+        VMSTATE_BOOL(is_connected, Stm32F4xx_Eth),
+        VMSTATE_END_OF_LIST()
+    }
+};
+
 static void stm32f4xx_eth_class_init(ObjectClass *klass, void *data)
 {
     DeviceClass *dc = DEVICE_CLASS(klass);
 
     dc->realize = stm32f4xx_eth_realize;
-    //dc->vmsd = &vmstate_xgmac;
+    dc->vmsd = &vmstate_stm32f4xx_eth;
     device_class_set_props(dc, stm32f4xx_eth_properties);
 }
 

--- a/hw/arm/prusa/stm32f407/stm32f4xx_iwdg.c
+++ b/hw/arm/prusa/stm32f407/stm32f4xx_iwdg.c
@@ -22,6 +22,7 @@
 #include "stm32f4xx_iwdg.h"
 #include "stm32_rcc.h"
 #include "qemu/log.h"
+#include "migration/vmstate.h"
 #include "sysemu/watchdog.h"
 #include "sysemu/runstate.h"
 #include "qapi/qapi-commands-run-state.h"
@@ -202,10 +203,25 @@ stm32f4xx_iwdg_init(Object *obj)
 
 }
 
+static const VMStateDescription vmstate_stm32f4xx_iwdg = {
+    .name = TYPE_STM32F4XX_IWDG,
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .fields = (VMStateField[]) {
+        VMSTATE_UINT32_ARRAY(regs.all,stm32f4xx_iwdg, R_IWDG_MAX),
+        VMSTATE_TIMER_PTR(timer, stm32f4xx_iwdg),
+        VMSTATE_BOOL(time_changed,stm32f4xx_iwdg),
+        VMSTATE_BOOL(started,stm32f4xx_iwdg),     
+        VMSTATE_END_OF_LIST()
+    }
+};
+
+
 static void
 stm32f4xx_iwdg_class_init(ObjectClass *klass, void *data)
 {
     DeviceClass *dc = DEVICE_CLASS(klass);
+    dc->vmsd = &vmstate_stm32f4xx_iwdg;
     dc->reset = stm32f4xx_iwdg_reset;
 }
 

--- a/hw/arm/prusa/stm32f407/stm32f4xx_otp.c
+++ b/hw/arm/prusa/stm32f407/stm32f4xx_otp.c
@@ -20,6 +20,7 @@
  */
 
 #include "stm32f4xx_otp.h"
+#include "migration/vmstate.h"
 #include "qemu/log.h"
 #include "../utility/macros.h"
 #include "hw/qdev-properties.h"
@@ -128,11 +129,22 @@ static Property stm32f4xx_otp_props[] = {
     DEFINE_PROP_END_OF_LIST()
 };
 
+static const VMStateDescription vmstate_stm32f4xx_otp = {
+    .name = TYPE_STM32F4XX_OTP,
+    .version_id = 1,
+    .minimum_version_id = 1,
+    .fields = (VMStateField[]) {
+        VMSTATE_UINT32_ARRAY(data,Stm32f4xx_OTP, OTP_SIZE),
+        VMSTATE_END_OF_LIST()
+    }
+};
+
 static void
 stm32f4xx_otp_class_init(ObjectClass *klass, void *data)
 {
     DeviceClass *dc = DEVICE_CLASS(klass);
     dc->realize = &stm32f4xx_otp_realize;
+    dc->vmsd = &vmstate_stm32f4xx_otp;
     device_class_set_props(dc, stm32f4xx_otp_props);
 
 }

--- a/hw/arm/prusa/stm32f407/stm32f4xx_usb.c
+++ b/hw/arm/prusa/stm32f407/stm32f4xx_usb.c
@@ -1679,7 +1679,15 @@ const VMStateDescription vmstate_STM32F4xx_state = {
                              vmstate_STM32F4xx_state_packet, STM32F4xxPacket),
         VMSTATE_UINT8_2DARRAY(usb_buf, STM32F4xxUSBState, STM32F4xx_NB_CHAN,
                               STM32F4xx_MAX_XFER_SIZE),
-
+        VMSTATE_UINT32_ARRAY(fifo_ram,STM32F4xxUSBState, STM32F4xx_RX_FIFO_SIZE),
+        VMSTATE_UINT32_2DARRAY(tx_fifos,STM32F4xxUSBState,STM32F4xx_NB_CHAN,STM32F4xx_EP_FIFO_SIZE),
+        VMSTATE_UINT16_ARRAY(fifo_head,STM32F4xxUSBState, STM32F4xx_NB_CHAN),
+        VMSTATE_UINT16_ARRAY(fifo_level,STM32F4xxUSBState, STM32F4xx_NB_CHAN),
+        VMSTATE_UINT16_ARRAY(fifo_tail,STM32F4xxUSBState, STM32F4xx_NB_CHAN),
+        VMSTATE_UINT32(rx_fifo_head,STM32F4xxUSBState),
+        VMSTATE_UINT32(rx_fifo_tail,STM32F4xxUSBState),
+        VMSTATE_UINT32(rx_fifo_level,STM32F4xxUSBState),
+        VMSTATE_UINT8(is_ping, STM32F4xxUSBState),
         VMSTATE_END_OF_LIST()
     }
 };

--- a/hw/arm/prusa/utility/macros.h
+++ b/hw/arm/prusa/utility/macros.h
@@ -56,3 +56,6 @@
                         MODULE_OBJ_NAME, PARENT_MODULE_OBJ_NAME) \
                         OBJECT_DEFINE_TYPE_SIMPLE_WITH_INTERFACES(ModuleObjName, module_obj_name, \
                             MODULE_OBJ_NAME, PARENT_MODULE_OBJ_NAME, {NULL}) 
+
+#define CHECK_ALIGN(x,y, name) static_assert(x == y, "ERROR - " name " register definition misaligned!")
+#define CHECK_REG_u32(reg) CHECK_ALIGN(sizeof(reg),sizeof(uint32_t),#reg "size incorrect!")

--- a/hw/arm/prusa/utility/macros.h
+++ b/hw/arm/prusa/utility/macros.h
@@ -59,3 +59,29 @@
 
 #define CHECK_ALIGN(x,y, name) static_assert(x == y, "ERROR - " name " register definition misaligned!")
 #define CHECK_REG_u32(reg) CHECK_ALIGN(sizeof(reg),sizeof(uint32_t),#reg "size incorrect!")
+
+// Some rather ugly convenience macros for 
+// more easily debugging save state symmetry. See the RCC implementation for
+// an example how this works. (STATE_DEBUG_VAR must be defined for it to work.)
+#ifdef STATE_DEBUG_VAR
+#define DEBUG_COPY(type, size) static type STATE_DEBUG_VAR[size]
+
+#define DEBUG_INDEX(value) uint8_t index = value
+
+#define DEBUG_TAKE(src,index) memcpy(&STATE_DEBUG_VAR[index],src, sizeof(STATE_DEBUG_VAR[index]))
+#define DEBUG_CHECK(field) assert(s->field == STATE_DEBUG_VAR[index].field)
+#define DEBUG_CHECKP(field) assert(s->field == STATE_DEBUG_VAR[index]->field)
+#define DEBUG_VERIFY DEBUG_LIST 
+#define DEBUG_CAST_ONLY(cast) cast
+#undef STATE_DEBUG_VAR
+#else
+
+#define DEBUG_COPY(type, size) 
+#define DEBUG_TAKE(src,index) 
+
+#define DEBUG_INDEX(value)
+#define DEBUG_CAST_ONLY(cast)
+#define DEBUG_CHECK(field)
+#define DEBUG_VERIFY 
+
+#endif


### PR DESCRIPTION
### Description

- Cleans up the UART implementation
- Adds save state capability to all parts. 

### Behaviour/ Breaking changes

Hopefully did not break the UARTs. We can still talk to the TMC drivers, so it should be fine ;)

### Have you tested the changes?

Yes, was able to save and load a snapshot and resume to where the snapshot was taken.

### Other

See the RCC implementation and macros.h for some useful savestate debug helpers. 

### Linked issues:

 - Closes #52 
 - Fixes #61 
