### PR TITLE
Fix CRC DR read if peripheral clock is disabled

### DIFF
--- a/hw/arm/prusa/stm32f407/stm32.h
+++ b/hw/arm/prusa/stm32f407/stm32.h
@@ -355,7 +355,7 @@ typedef struct Stm32Rcc Stm32Rcc;
 /* Checks if the specified peripheral clock is enabled.
  * Generates a hardware error if not.
  */
-void stm32_rcc_check_periph_clk(Stm32Rcc *s, stm32_periph_t periph);
+bool stm32_rcc_check_periph_clk(Stm32Rcc *s, stm32_periph_t periph);
 
 /* Sets the IRQ to be called when the specified peripheral clock changes
  * frequency. */

--- a/hw/arm/prusa/stm32f407/stm32_rcc.c
+++ b/hw/arm/prusa/stm32f407/stm32_rcc.c
@@ -1,7 +1,7 @@
 #include "stm32_rcc.h"
 /* PUBLIC FUNCTIONS */
 
-void stm32_rcc_check_periph_clk(Stm32Rcc *s, stm32_periph_t periph)
+bool stm32_rcc_check_periph_clk(Stm32Rcc *s, stm32_periph_t periph)
 {
     Clk_p clk = &s->PERIPHCLK[periph];
 
@@ -14,7 +14,9 @@ void stm32_rcc_check_periph_clk(Stm32Rcc *s, stm32_periph_t periph)
          */
         printf("Warning: You are attempting to use the stm32_rcc peripheral while "
                  "its clock is disabled.\n");
+        return false;
     }
+    return true;
 }
 
 void stm32_rcc_set_periph_clk_irq(

--- a/hw/arm/prusa/stm32f407/stm32f2xx_crc.c
+++ b/hw/arm/prusa/stm32f407/stm32f2xx_crc.c
@@ -130,7 +130,7 @@ f2xx_crc_read(void *arg, hwaddr addr, unsigned int size)
         }
         else
         {
-            return 0xFFFFFFFFU;
+            return 0;
         }
     case R_CRC_IDR:
         return s->idr;

--- a/hw/arm/prusa/stm32f407/stm32f2xx_crc.c
+++ b/hw/arm/prusa/stm32f407/stm32f2xx_crc.c
@@ -25,6 +25,7 @@
 #include "stm32f2xx_crc.h"
 #include "migration/vmstate.h"
 #include "qemu/log.h"
+#include "stm32_rcc.h"
 
 #define R_CRC_DR            (0x00 / 4)
 #define R_CRC_DR_RESET 0xffffffff
@@ -123,7 +124,14 @@ f2xx_crc_read(void *arg, hwaddr addr, unsigned int size)
     }
     switch(addr) {
     case R_CRC_DR:
-        return s->crc;
+        if (s->rcc && stm32_rcc_check_periph_clk(s->rcc, STM32_CRC)) 
+        {
+            return s->crc;
+        }
+        else
+        {
+            return 0xFFFFFFFFU;
+        }
     case R_CRC_IDR:
         return s->idr;
     }

--- a/hw/arm/prusa/stm32f407/stm32f2xx_crc.h
+++ b/hw/arm/prusa/stm32f407/stm32f2xx_crc.h
@@ -29,6 +29,8 @@
 #include "qemu-common.h"
 #include "hw/sysbus.h"
 
+typedef struct Stm32Rcc Stm32Rcc;
+
 #define TYPE_STM32F2XX_CRC "stm32f2xx-crc"
 OBJECT_DECLARE_SIMPLE_TYPE(f2xx_crc,STM32F2XX_CRC);
 
@@ -38,6 +40,8 @@ typedef struct f2xx_crc {
 
     uint32_t crc;
     uint8_t idr;
+
+    Stm32Rcc* rcc;
 } f2xx_crc;
 
 #endif // STM32F2XX_CRC_H

--- a/hw/arm/prusa/stm32f407/stm32f407_soc.c
+++ b/hw/arm/prusa/stm32f407/stm32f407_soc.c
@@ -418,6 +418,7 @@ static void stm32f407_soc_realize(DeviceState *dev_soc, Error **errp)
     sysbus_mmio_map(busdev, 0, 0x40002800);
 
     dev = DEVICE(&s->crc);
+    s->crc.rcc = (Stm32Rcc*)&s->rcc;
     if (!sysbus_realize(SYS_BUS_DEVICE(&s->crc),errp))
         return;
     busdev = SYS_BUS_DEVICE(dev);

--- a/hw/arm/prusa/stm32f407/stm32f4xx_iwdg.c
+++ b/hw/arm/prusa/stm32f407/stm32f4xx_iwdg.c
@@ -179,6 +179,7 @@ static void stm32f4xx_iwdg_reset(DeviceState *dev)
     stm32f4xx_iwdg *s = STM32F4XX_IWDG(dev);
     if (s->timer) {
         timer_del(s->timer);
+        g_free(s->timer);
         s->timer = timer_new_ns(QEMU_CLOCK_VIRTUAL, stm32f4xx_iwdg_fire, s);
     }
     memset(&s->regs, 0, sizeof(s->regs));


### PR DESCRIPTION
### Description

Fix for #82 

### Behaviour/ Breaking changes

CRC DR now returns ~0xFFFFFFFF~ 0 if the clock is disabled.

### Other

Fixes a memory leak in the IWDG reset function.

### Linked issues:

 - Closes #82 
- Partial for #81 