### PR TITLE
Fake usb cdc

### DIFF
--- a/hw/arm/prusa/stm32f407/stm32f407_soc.c
+++ b/hw/arm/prusa/stm32f407/stm32f407_soc.c
@@ -462,6 +462,10 @@ static void stm32f407_soc_realize(DeviceState *dev_soc, Error **errp)
     busdev = SYS_BUS_DEVICE(dev);
     sysbus_mmio_map(busdev, 0, 0xE0000000UL);
 
+    dev = DEVICE(&s->otg_fs);
+    s->otg_fs.debug = true;
+    qdev_prop_set_chr(dev, "chardev", qemu_chr_find("stm32usbfscdc"));
+
     // IRQs: FS wakeup: 42 FS Global: 67
     if (!sysbus_realize(SYS_BUS_DEVICE(&s->otg_fs),errp))
     {
@@ -469,7 +473,8 @@ static void stm32f407_soc_realize(DeviceState *dev_soc, Error **errp)
     }    
     memory_region_add_subregion(system_memory, 0x50000000UL,
         sysbus_mmio_get_region(SYS_BUS_DEVICE(&s->otg_fs), 0));
-
+    sysbus_connect_irq(SYS_BUS_DEVICE(&s->otg_fs), 0, qdev_get_gpio_in(armv7m, 67));
+   // qdev_connect_gpio_out_named(rcc,"reset",STM32_USB,qdev_get_gpio_in_named(DEVICE(&s->otg_hs),"rcc-reset",0));
 
     // USB IRQs:
     // Global HS: 77. WKUP: 76, EP1 in/out = 75/74.

--- a/hw/arm/prusa/stm32f407/stm32f407_soc.c
+++ b/hw/arm/prusa/stm32f407/stm32f407_soc.c
@@ -463,7 +463,7 @@ static void stm32f407_soc_realize(DeviceState *dev_soc, Error **errp)
     sysbus_mmio_map(busdev, 0, 0xE0000000UL);
 
     dev = DEVICE(&s->otg_fs);
-    s->otg_fs.debug = true;
+    //s->otg_fs.debug = true;
     qdev_prop_set_chr(dev, "chardev", qemu_chr_find("stm32usbfscdc"));
 
     // IRQs: FS wakeup: 42 FS Global: 67

--- a/hw/arm/prusa/stm32f407/stm32f4xx_usb.c
+++ b/hw/arm/prusa/stm32f407/stm32f4xx_usb.c
@@ -431,9 +431,9 @@ static void f4xx_usb_cdc_sendpkt(STM32F4xxUSBState *s, const uint32_t* pBuff, co
 // Responsible for the initial handshake once device mode is enabled. 
 static void f4xx_usb_cdc_setup(STM32F4xxUSBState *s) 
 {
-    // if (!qemu_chr_fe_backend_connected(&s->cdc)) {
-    //     return;
-    // }
+    if (!qemu_chr_fe_backend_connected(&s->cdc)) {
+        return;
+    }
 
     if (s->debug) printf("USB CDC enable state: %u\n", s->device_state);
     switch (s->device_state) {

--- a/hw/arm/prusa/stm32f407/stm32f4xx_usb.c
+++ b/hw/arm/prusa/stm32f407/stm32f4xx_usb.c
@@ -30,32 +30,86 @@
 #include "qemu/osdep.h"
 #include "qemu/units.h"
 #include "qapi/error.h"
-#include "hw/usb/dwc2-regs.h"
 #include "stm32f4xx_usb.h"
+#include "hw/usb/dwc2-regs.h"
+
+#undef DCTL
+#undef DCFG
+#undef DAINT
+#undef DAINTMSK
+#undef GINTSTS
+
 #include "migration/vmstate.h"
 #include "trace.h"
 #include "qemu/log.h"
 #include "qemu/error-report.h"
 #include "qemu/main-loop.h"
 #include "hw/qdev-properties.h"
+#include "usbip.h"
 
 #define USB_HZ_FS       12000000
 #define USB_HZ_HS       96000000 // was 96, this might be wrong but STM clocks usb at 48 mhz
 #define USB_FRMINTVL    12000
 
-/* nifty macros from Arnon's EHCI version  */
-#define get_field(data, field) \
-    (((data) & field##_MASK) >> field##_SHIFT)
+#define R_GINTSTS  (0x014/4)
 
-#define set_field(data, newval, field) do { \
-    uint32_t val = *(data); \
-    val &= ~field##_MASK; \
-    val |= ((newval) << field##_SHIFT) & field##_MASK; \
-    *(data) = val; \
-} while (0)
+#define R_HCCHAR    0x00/4
+#define R_HCSPLT    0x04/4
+#define R_HCINT     0x08/4
+#define R_HCINTMSK  0x0C/4 
+#define R_HCTSIZ    0x10/4
+#define R_HCDMA     0x14/4
 
-#define get_bit(data, bitmask) \
-    (!!((data) & (bitmask)))
+#define R_DCFG          (0x800/4)
+#define R_DCTL          (0x804/4)
+#define R_DIEPMSK       (0x810/4)
+#define R_DOEPMSK       (0x814/4)
+#define R_DAINT         (0x818/4)
+#define R_DAINTMSK      (0x81C/4)
+#define R_DIEPEMPMSK    (0x834/4)
+
+#define R_OFF_DEPCTL 0
+#define R_OFF_DEPINT 2
+#define R_OFF_DTXFSTS 6
+
+#define R_PCGCTL (0xE00/4)
+#define R_PCGCCTL1 (0xE04/4)
+
+/* USBIP handling */ 
+#define BSIZE 64 
+char buffer[BSIZE+1];
+int  bsize=0;
+
+#define DEV_ADDR  4U
+static const uint32_t DEV_SETADDR[] = {0x000C0040,  (0x00000500 | (DEV_ADDR<<16)), 0x00000000};
+static const uint32_t DEV_GETDESC[] = {0x000C0040, 0x03020680, 0x00FF0000};
+static const uint32_t DEV_GETDESC2[] = {0x000C0040, 0x03010680, 0x00FF0000};
+static const uint32_t DEV_GETDESC3[] = {0x000C0040, 0x03030680, 0x00FF0000};
+static const uint32_t DEV_SETCONF[] = {0x000C0040, 0x00010900, 0x00000000};
+// static const uint32_t DEV_SETCODING[] = {0x000C0040, 0x00002021, 0x00070000};
+// static const uint32_t DEV_SETCODING2[] = {0x00040070, 0x00002500, 0x00080000};
+static const uint32_t DEV_SETCTLLINE[] = {0x000C0040, 0x00032221, 0x00000000};
+static const uint32_t DEV_OUT_HEADER = 0x40011;
+static const uint32_t DEV_OUT_AT[] = {0x00040021, 0x00000a0d};
+//void handle_data(int sockfd, USBIP_RET_SUBMIT *usb_req, int bl)
+
+#define DEVSTATE(name) DEV_ST_##name, DEV_ST_##name##_WAIT,
+
+
+enum {
+    DEVSTATE(RESET)
+    DEVSTATE(SETUP)
+    DEVSTATE(DESCR)
+    DEVSTATE(DESCR2)
+    DEVSTATE(DESCR3)
+    DEVSTATE(SETCFG)
+    DEVSTATE(LINECODING)
+    DEVSTATE(LINECODING_DATA)
+    DEVSTATE(SETCTLLINE)
+    DEV_ST_IO_READY,
+    DEVSTATE(IO)
+};
+
 
 /* update irq line */
 static inline void STM32F4xx_update_irq(STM32F4xxUSBState *s)
@@ -80,6 +134,7 @@ static inline void STM32F4xx_raise_global_irq(STM32F4xxUSBState *s, uint32_t int
         s->gintsts |= intr;
         // trace_usb_stm_raise_global_irq(intr);
         STM32F4xx_update_irq(s);
+
     }
 }
 
@@ -115,17 +170,130 @@ static inline void STM32F4xx_lower_host_irq(STM32F4xxUSBState *s, uint32_t host_
     }
 }
 
+
 static inline void STM32F4xx_update_hc_irq(STM32F4xxUSBState *s, int index)
 {
     uint32_t host_intr = 1 << (index >> 3);
+    uint32_t chan = index>>3;
 
-    if (s->hreg1[index + 2] & s->hreg1[index + 3]) {
+    if (s->hreg_chan[chan].raw[R_HCINT] & s->hreg_chan[chan].raw[R_HCINTMSK]) {
         STM32F4xx_raise_host_irq(s, host_intr);
     } else {
         STM32F4xx_lower_host_irq(s, host_intr);
     }
 }
 
+// static inline void STM32F4xx_raise_device_common_irq(STM32F4xxUSBState *s, int ep, bool is_out) {
+//     uint32_t bitval = BIT( is_out? ep+16 : ep );
+
+//     if (!(s->dreg0[R_DAINT - R_DCFG] & bitval)) {
+//         s->dreg0[R_DAINT - R_DCFG] |= bitval;
+//         if (is_out && (s->dreg_defs.DAINTMSK.OEPM & s->dreg_defs.DAINT.OEPINT)) 
+//         {
+//             STM32F4xx_raise_global_irq(s, GINTSTS_OEPINT);
+//         }
+//         if (!is_out && (s->dreg_defs.DAINTMSK.IEPM & s->dreg_defs.DAINT.IEPINT)) 
+//         {
+//             STM32F4xx_raise_global_irq(s, GINTSTS_IEPINT);
+//         }
+//     }
+// }
+
+// static inline void STM32F4xx_lower_device_common_irq(STM32F4xxUSBState *s, int ep, bool is_out) {
+//     uint32_t bitval = BIT( is_out? ep+16 : ep );
+
+//     if ((s->dreg0[R_DAINT - R_DCFG] & bitval)) {
+//         s->dreg0[R_DAINT - R_DCFG] &= ~bitval;
+//         if (is_out && (s->dreg_defs.DAINTMSK.OEPM & s->dreg_defs.DAINT.OEPINT)==0) 
+//         {
+//             STM32F4xx_lower_global_irq(s, GINTSTS_OEPINT);
+//         }
+//         if (!is_out && (s->dreg_defs.DAINTMSK.IEPM & s->dreg_defs.DAINT.IEPINT)==0) 
+//         {
+//             STM32F4xx_lower_global_irq(s, GINTSTS_IEPINT);
+//         }
+        
+//     }
+// }
+
+static inline void STM32F4xx_update_device_common_irq(STM32F4xxUSBState *s) 
+{
+    uint32_t common_val = 0;
+    bool raise_irq = 0;
+    for (int i=0; i< STM32F4xx_NB_DEVCHAN; i++) {
+        if (s->drego[i].raw[R_OFF_DEPINT]) 
+        {
+            common_val |= (1U << i) << 16U;
+            raise_irq |= (s->drego[i].raw[R_OFF_DEPINT] & s->dreg0[R_DOEPMSK-R_DCFG])>0; 
+        }
+        if (s->dregi[i].raw[R_OFF_DEPINT]) 
+        {
+            common_val |= (1U << i);
+            raise_irq |= (s->dregi[i].raw[R_OFF_DEPINT] & s->dreg0[R_DIEPMSK-R_DCFG])>0; 
+        }
+    }
+    if (common_val^s->dreg0[R_DAINT-R_DCFG]) 
+    {
+        // There's a change in the common reg. Update global accordingly. 
+        s->dreg0[R_DAINT-R_DCFG] = common_val;
+        if (!raise_irq)  // Stop here if IRQs are masked.
+        {
+            return;
+        }
+        if (s->dreg_defs.DAINT.OEPINT & s->dreg_defs.DAINTMSK.OEPM) 
+        {
+            STM32F4xx_raise_global_irq(s, GINTSTS_OEPINT);
+        }
+        else 
+        {
+            STM32F4xx_lower_global_irq(s, GINTSTS_OEPINT);
+        }
+        if (s->dreg_defs.DAINT.IEPINT & s->dreg_defs.DAINTMSK.IEPM) 
+        {
+            STM32F4xx_raise_global_irq(s, GINTSTS_IEPINT);
+        }
+        else 
+        {
+            STM32F4xx_lower_global_irq(s, GINTSTS_IEPINT);
+        }
+    }
+}
+
+static inline void STM32F4xx_raise_device_ep_out_irq(STM32F4xxUSBState *s, int ep, uint32_t dev_intr)
+{
+    if (!(s->drego[ep].raw[R_OFF_DEPINT] & dev_intr)) 
+    {
+        s->drego[ep].raw[R_OFF_DEPINT] |= dev_intr;
+        STM32F4xx_update_device_common_irq(s);
+    }
+}
+
+static inline void STM32F4xx_lower_device_ep_out_irq(STM32F4xxUSBState *s, int ep, uint32_t dev_intr)
+{
+    if (s->drego[ep].raw[R_OFF_DEPINT] & dev_intr) 
+    {
+        s->drego[ep].raw[R_OFF_DEPINT] &= ~dev_intr;
+        STM32F4xx_update_device_common_irq(s);
+    }
+}
+
+static inline void STM32F4xx_raise_device_ep_in_irq(STM32F4xxUSBState *s, int ep, uint32_t dev_intr)
+{
+    if (!(s->dregi[ep].raw[R_OFF_DEPINT] & dev_intr)) 
+    {
+        s->dregi[ep].raw[R_OFF_DEPINT] |= dev_intr;
+        STM32F4xx_update_device_common_irq(s);
+    }
+}
+
+static inline void STM32F4xx_lower_device_ep_in_irq(STM32F4xxUSBState *s, int ep, uint32_t dev_intr)
+{
+    if (s->dregi[ep].raw[R_OFF_DEPINT] & dev_intr) 
+    {
+        s->dregi[ep].raw[R_OFF_DEPINT] &= ~dev_intr;
+        STM32F4xx_update_device_common_irq(s);
+    }
+}
 /* set a timer for EOF */
 static void STM32F4xx_eof_timer(STM32F4xxUSBState *s)
 {
@@ -182,7 +350,7 @@ static USBDevice *STM32F4xx_find_device(STM32F4xxUSBState *s, uint8_t addr)
 
     trace_usb_stm_find_device(addr);
 
-    if (!(s->hprt0 & HPRT0_ENA)) {
+    if (!(s->HPRT.PENA)) {
         trace_usb_stm_port_disabled(0);
     } else {
         dev = usb_find_device(&s->uport, addr);
@@ -216,38 +384,232 @@ static const char *dirs[] = {
     "Out", "In"
 };
 
+// CDC block handlers:
+
+static void STM32F4xx_cdc_schedule(STM32F4xxUSBState *s) {
+    timer_mod(s->cdc_timer, qemu_clock_get_us(QEMU_CLOCK_VIRTUAL) + 1);
+}
+
+static int f4xx_usb_cdc_can_receive(void *opaque)
+{
+    STM32F4xxUSBState *s = STM32F4xx_USB(opaque);
+    return s->cdc_in == 0;
+}
+
+static void f4xx_usb_cdc_receive(void *opaque, const uint8_t *buf, int size)
+{
+    STM32F4xxUSBState *s = STM32F4xx_USB(opaque);
+
+    assert(size > 0);
+    /* Copy the characters into our buffer first */
+    // if (s->periph==19) {
+    s->cdc_in = buf[0];
+        printf("CDC RX: ");
+        for (int i=0; i<size;i++)
+            printf("%c",buf[i]);
+        printf("\n");
+    STM32F4xx_cdc_schedule(s);
+    // }
+    // TODO - forward chars to a packet.
+}
+
+static void f4xx_usb_cdc_sendpkt(STM32F4xxUSBState *s, const uint32_t* pBuff, const uint32_t len) 
+{
+    for (int i=0; i<len; i++) {
+        s->fifo_ram[i] = pBuff[i];
+        s->rx_fifo_tail = len;
+        s->rx_fifo_level = len;
+        s->rx_fifo_head = 0;
+    }
+}
+
+// Responsible for the initial handshake once device mode is enabled. 
+static void f4xx_usb_cdc_setup(STM32F4xxUSBState *s) 
+{
+    // if (!qemu_chr_fe_backend_connected(&s->cdc)) {
+    //     return;
+    // }
+
+    printf("USB CDC enable state: %u\n", s->device_state);
+    switch (s->device_state) {
+        case DEV_ST_RESET:
+        {
+            STM32F4xx_raise_global_irq(s, GINTSTS_CONIDSTSCHNG | GINTSTS_USBRST | GINTSTS_ENUMDONE);
+            s->device_state = DEV_ST_RESET_WAIT;
+        }
+        break;
+        case DEV_ST_SETUP:
+        {
+            s->device_state = DEV_ST_SETUP_WAIT;
+            // Construct ctl set address packet:
+            f4xx_usb_cdc_sendpkt(s, DEV_SETADDR, sizeof(DEV_SETADDR)/sizeof(uint32_t));
+            STM32F4xx_raise_device_ep_out_irq(s, 0, DOEPMSK_SETUPMSK);
+            STM32F4xx_raise_global_irq(s, GINTSTS_RXFLVL);
+        }
+        break;
+        case DEV_ST_SETUP_WAIT:
+            s->dregi[0].DIEPCTL.EPENA = 0;
+            s->device_state = DEV_ST_DESCR;
+            STM32F4xx_cdc_schedule(s);
+            qemu_chr_fe_write_all(&s->cdc, (const uint8_t*)"STM32F4xx USB CDC emulation started with device:\r\n", 50);
+            break;
+        case DEV_ST_DESCR:
+        case DEV_ST_DESCR2:
+        case DEV_ST_DESCR3:
+            switch (s->device_state) {
+                case DEV_ST_DESCR:
+                    f4xx_usb_cdc_sendpkt(s, DEV_GETDESC, sizeof(DEV_GETDESC)/sizeof(uint32_t));
+                    break;
+                case DEV_ST_DESCR2:
+                    f4xx_usb_cdc_sendpkt(s, DEV_GETDESC2, sizeof(DEV_GETDESC2)/sizeof(uint32_t));
+                    break;
+                case DEV_ST_DESCR3:
+                    f4xx_usb_cdc_sendpkt(s, DEV_GETDESC3, sizeof(DEV_GETDESC3)/sizeof(uint32_t));
+                    break;
+            }            
+            s->device_state++;
+            STM32F4xx_raise_device_ep_in_irq(s, 0, DIEPMSK_TXFIFOEMPTY);
+            STM32F4xx_raise_device_ep_out_irq(s, 0, DOEPMSK_SETUPMSK);
+            STM32F4xx_raise_global_irq(s, GINTSTS_RXFLVL);
+        break;
+        case DEV_ST_DESCR_WAIT:
+        case DEV_ST_DESCR2_WAIT:
+        case DEV_ST_DESCR3_WAIT:
+            if (s->fifo_level[0]==0) // Data not ready yet. EP is enabled before fifo written.
+             
+                break;
+            // Print out descriptor to chardev.
+            {
+                uint32_t charcount = s->fifo_level[0]*sizeof(uint32_t);
+                uint8_t* pBuff = (uint8_t*)&s->tx_fifos[0][s->fifo_head[0]];
+                for (int i=2; i<charcount; i+=2)
+                    qemu_chr_fe_write(&s->cdc, &pBuff[i],1);
+                const uint8_t nline[] = "\r\n";
+                qemu_chr_fe_write(&s->cdc, nline,2);
+                
+            }
+            s->fifo_level[0]=0;
+            s->fifo_tail[0]=0;
+            s->dregi[0].DIEPCTL.EPENA = 0;
+            s->device_state++;
+            STM32F4xx_cdc_schedule(s);
+        break;
+        case DEV_ST_SETCFG:
+            STM32F4xx_lower_device_ep_in_irq(s, 0, DIEPMSK_TXFIFOEMPTY);
+            f4xx_usb_cdc_sendpkt(s, DEV_SETCONF, sizeof(DEV_SETCONF)/sizeof(uint32_t));
+            STM32F4xx_raise_device_ep_out_irq(s, 0, DOEPMSK_SETUPMSK);
+            STM32F4xx_raise_global_irq(s, GINTSTS_RXFLVL);
+            s->device_state++;
+            break;
+        case DEV_ST_SETCFG_WAIT:
+            s->device_state++;
+            s->dregi[0].DIEPCTL.EPENA = 0;
+            STM32F4xx_cdc_schedule(s);
+            break;
+        case DEV_ST_LINECODING:
+            s->device_state = DEV_ST_SETCTLLINE;
+        //     f4xx_usb_cdc_sendpkt(s, DEV_SETCODING, sizeof(DEV_SETCODING)/sizeof(uint32_t));
+        //     STM32F4xx_raise_device_ep_out_irq(s, 0, DOEPMSK_SETUPMSK);
+        //     STM32F4xx_raise_global_irq(s, GINTSTS_RXFLVL);
+        //     break;
+        // case DEV_ST_LINECODING_WAIT:
+        //     s->device_state++;
+        //     STM32F4xx_cdc_schedule(s);
+        //     break;
+        // case DEV_ST_LINECODING_DATA:
+        //     f4xx_usb_cdc_sendpkt(s, DEV_SETCODING2, sizeof(DEV_SETCODING2)/sizeof(uint32_t));
+        //     s->drego[0].DOEPCTL.EPENA = 0;
+        //     STM32F4xx_raise_global_irq(s, GINTSTS_RXFLVL);
+        //     STM32F4xx_raise_device_ep_out_irq(s, 0, DOEPMSK_SETUPMSK | DOEPMSK_XFERCOMPLMSK);
+        //     s->device_state++;
+        //     break;
+        // case DEV_ST_LINECODING_DATA_WAIT:
+        //     s->drego[0].DIEPTSIZ.XFRSIZ = 0;
+        //     s->device_state++;
+        //     STM32F4xx_cdc_schedule(s);
+        //     break;
+        // FALLTHRU // (because set linecoding doesn't actually do anything)
+        case DEV_ST_SETCTLLINE:
+            f4xx_usb_cdc_sendpkt(s, DEV_SETCTLLINE, sizeof(DEV_SETCTLLINE)/sizeof(uint32_t));
+            STM32F4xx_raise_device_ep_out_irq(s, 0, DOEPMSK_SETUPMSK);
+            printf("DOEPINT: %08x (bit %u)\n", s->drego[0].raw[R_OFF_DEPINT], s->drego[0].DOEPINT.STUP);
+            STM32F4xx_raise_global_irq(s, GINTSTS_RXFLVL);
+            s->device_state++;
+            break;
+        case DEV_ST_SETCTLLINE_WAIT:
+            qemu_chr_fe_write_all(&s->cdc, (const uint8_t*)"Control line set\r\n",18);
+            s->device_state++;
+            STM32F4xx_cdc_schedule(s);
+            break;
+        case DEV_ST_IO_READY:
+            STM32F4xx_lower_global_irq(s, GINTSTS_OEPINT);
+            qemu_chr_fe_accept_input(&s->cdc);
+            s->device_state++;
+            // ugly hack, figure out why the hal is locked in HAL_PCD_EP_Open during USBD_CDC_Init...
+            s->dreg_defs.DAINTMSK.OEPM |=2;
+            s->dreg_defs.DAINTMSK.IEPM |=2;
+            break;
+        case DEV_ST_IO:
+            if (s->cdc_in!=0)
+            {
+                if (s->cdc_in == '\n') 
+                {
+                    f4xx_usb_cdc_sendpkt(s, DEV_OUT_AT, sizeof(DEV_OUT_AT)/sizeof(uint32_t));
+                }
+                else
+                {
+                    f4xx_usb_cdc_sendpkt(s, &DEV_OUT_HEADER, 1);
+                    s->rx_fifo_level++;
+                    s->rx_fifo_tail++;
+                    s->fifo_ram[1] = 0 | (s->cdc_in);
+                }
+                s->cdc_in = 0;
+                STM32F4xx_raise_device_ep_out_irq(s, 1, DOEPMSK_XFERCOMPLMSK);
+                STM32F4xx_raise_global_irq(s, GINTSTS_RXFLVL);
+            }
+        // default:            STM32F4xx_raise_device_ep_in_irq(s, 0, DIEPMSK_TXFIFOEMPTY);
+
+
+    }
+    // Set address
+    // Get descroptors
+    // Set config
+    // Set line control
+    // Done - free to send/receive serial data.
+}
+
+static void STM32F4xx_cdc_helper(void* opaque) {
+    f4xx_usb_cdc_setup((STM32F4xxUSBState *)opaque);
+}
+
+// end CDC handlers.
+
 static void STM32F4xx_handle_packet(STM32F4xxUSBState *s, uint32_t devadr, USBDevice *dev,
                                USBEndpoint *ep, uint32_t index, bool send)
 {
     STM32F4xxPacket *p;
-    uint32_t hcchar = s->hreg1[index];
-    uint32_t hctsiz = s->hreg1[index + 4];
-    // uint32_t hcdma = s->hreg1[index + 5];
-    uint32_t chan, epnum, epdir, eptype, mps, pid, pcnt, len, tlen, intr = 0;
+    uint32_t chan = index >> 3;
+    hreg_set_t* r_chan = &s->hreg_chan[chan];
+    hctsiz_t* hctsiz = &r_chan->defs.HCTSIZ;
+    hcchar_t* hcchar = &r_chan->defs.HCCHAR;
+    uint32_t pid, tlen, intr = 0;
     uint32_t tpcnt, stsidx, actual = 0;
     bool do_intr = false, done = false;
 
-    epnum = get_field(hcchar, HCCHAR_EPNUM);
-    epdir = get_bit(hcchar, HCCHAR_EPDIR);
-    eptype = get_field(hcchar, HCCHAR_EPTYPE);
-    mps = get_field(hcchar, HCCHAR_MPS);
-    pid = get_field(hctsiz, TSIZ_SC_MC_PID);
-    pcnt = get_field(hctsiz, TSIZ_PKTCNT);
-    len = get_field(hctsiz, TSIZ_XFERSIZE);
-    assert(len <= STM32F4xx_MAX_XFER_SIZE);
-    chan = index >> 3;
+    pid = hctsiz->DPID;
+    assert(hctsiz->XFRSIZ <= STM32F4xx_MAX_XFER_SIZE);
     p = &s->packet[chan];
 
-    if (hcchar & HCCHAR_CHDIS)
+    if (hcchar->CHDIS)
     {
         printf("Channel %u disabled, ignoring.\n",chan);
         return;
     }
 
-    if (hctsiz & TSIZ_DOPNG){
+    if (hctsiz->DOPING){
         // Ping packet. just ACK it. 
         if (!s->is_ping) {
-            s->hreg1[index + 2] |= HCINTMSK_ACK;
+            r_chan->defs.HCINT.ACK |= r_chan->defs.HCINTMSK.ACKM;
             // s->hreg1[index + 4] &= ~TSIZ_DOPNG; // clear ping bit, it's done.
             // printf("PING ack'ed (EN: %u), tsiz: %08x\n",(hcchar & HCCHAR_CHDIS)>0, s->hreg1[index+4]);
             // s->hreg1[index] &= (~HCCHAR_CHENA);
@@ -258,9 +620,7 @@ static void STM32F4xx_handle_packet(STM32F4xxUSBState *s, uint32_t devadr, USBDe
         } else {
             s->is_ping = false;
             // printf("Ping complete\n");
-            s->hreg1[index] &= (~HCCHAR_CHENA);
- //           s->hreg1[index] &= (~HCCHAR_CHENA);
-
+            hcchar->CHENA = false;
         }
        // s->is_ping = true;
         STM32F4xx_update_hc_irq(s, index);
@@ -271,28 +631,33 @@ static void STM32F4xx_handle_packet(STM32F4xxUSBState *s, uint32_t devadr, USBDe
         s->is_ping = false;
     }
 
-    trace_usb_stm_handle_packet(chan, dev, &p->packet, epnum, types[eptype],
-                                 dirs[epdir], mps, len, pcnt);
+    trace_usb_stm_handle_packet(chan, dev, &p->packet, 
+            hcchar->EPNUM, 
+            types[hcchar->EPTYP],
+            dirs[hcchar->EPDIR], 
+            hcchar->MPSIZ, 
+            hctsiz->XFRSIZ,
+            hctsiz->PKTCNT);
 
 
-    if(pcnt==0)
+    if(hctsiz->PKTCNT==0)
     {
         //printf("pcnt=0, returning.\n"); // TODO - figure out why this happens and the halt reenables the channel.
-        s->hreg1[index] &= (~HCCHAR_CHENA);
+        r_chan->defs.HCCHAR.CHENA = false;
         return;
     }
 
-    if (eptype == USB_ENDPOINT_XFER_CONTROL && pid == TSIZ_SC_MC_PID_SETUP) {
+    if (hcchar->EPTYP == USB_ENDPOINT_XFER_CONTROL && hctsiz->DPID == TSIZ_SC_MC_PID_SETUP) {
         pid = USB_TOKEN_SETUP;
     } else {
-        pid = epdir ? USB_TOKEN_IN : USB_TOKEN_OUT;
+        pid = hcchar->EPDIR ? USB_TOKEN_IN : USB_TOKEN_OUT;
     }
 
     if (send) {
-        tlen = len;
+        tlen = hctsiz->XFRSIZ;
         if (p->small) {
-            if (tlen > mps) {
-                tlen = mps;
+            if (tlen > hcchar->MPSIZ) {
+                tlen = hcchar->MPSIZ;
             }
         }
 
@@ -331,7 +696,7 @@ static void STM32F4xx_handle_packet(STM32F4xxUSBState *s, uint32_t devadr, USBDe
         usb_packet_init(&p->packet);
         usb_packet_setup(&p->packet, pid, ep, 0, s->fifo_head[chan],
                          pid != USB_TOKEN_IN, true);
-        usb_packet_addbuf(&p->packet, s->usb_buf[chan], len);
+        usb_packet_addbuf(&p->packet, s->usb_buf[chan], hctsiz->XFRSIZ);
         p->async = STM32F4xx_ASYNC_NONE;
         usb_handle_packet(dev, &p->packet);
     } else {
@@ -352,17 +717,17 @@ babble:
     }
 
     if (p->packet.status == USB_RET_ASYNC) {
-        trace_usb_stm_async_packet(&p->packet, chan, dev, epnum,
-                                    dirs[epdir], tlen);
+        trace_usb_stm_async_packet(&p->packet, chan, dev, hcchar->EPNUM,
+                                    dirs[hcchar->EPDIR], tlen);
         usb_device_flush_ep_queue(dev, ep);
         assert(p->async != STM32F4xx_ASYNC_INFLIGHT);
         p->devadr = devadr;
-        p->epnum = epnum;
-        p->epdir = epdir;
-        p->mps = mps;
+        p->epnum = hcchar->EPNUM;
+        p->epdir = hcchar->EPDIR;
+        p->mps = hcchar->MPSIZ;
         p->pid = pid;
         p->index = index;
-        p->pcnt = pcnt;
+        p->pcnt = hctsiz->PKTCNT;
         p->len = tlen;
         p->async = STM32F4xx_ASYNC_INFLIGHT;
         p->needs_service = false;
@@ -379,8 +744,8 @@ babble:
             // First constuct the packet header
             if (actual>0) {
                 trace_usb_stm_memory_write(s->rx_fifo_tail, actual);
-                uint32_t dpid = get_field(s->hctsiz(chan), TSIZ_SC_MC_PID);
-                rxstatus_t header = {.chnum = chan, .bcnt = actual, .dpid = dpid, .pktsts = 0b0010};
+                rxstatus_t header = {.chnum = chan, .bcnt = actual, .dpid = hctsiz->DPID, .pktsts = 0b0010};
+                printf("packet in, size: %u\n",actual);
                 // uint32_t orig_head =s->rx_fifo_tail;
                 uint32_t words = (actual>>2); // +1 for header.
                 if (actual%4 !=0) {
@@ -423,7 +788,7 @@ babble:
             else
             {
                 printf("Incoming size 0, doping: %u\n",s->is_ping);
-                pcnt--;
+                hctsiz->PKTCNT--;
                 // if (s->is_ping)
                 // {
                 //     intr |= HCINTMSK_ACK | HCINTMSK_XFERCOMPL;
@@ -441,8 +806,8 @@ babble:
             // }
         } 
 
-        tpcnt = actual / mps;
-        if (actual % mps || tlen==0) {
+        tpcnt = actual / hcchar->MPSIZ;
+        if (actual % hcchar->MPSIZ || tlen==0) {
             tpcnt++;
             if (pid == USB_TOKEN_IN) {
                 done = true;
@@ -450,29 +815,26 @@ babble:
             }
         }
 
-        pcnt -= tpcnt < pcnt ? tpcnt : pcnt;
-        set_field(&hctsiz, pcnt, TSIZ_PKTCNT);
-        len -= actual < len ? actual : len;
-        set_field(&hctsiz, len, TSIZ_XFERSIZE);
-        s->hreg1[index + 4] = hctsiz;
+        hctsiz->PKTCNT -= MIN(tpcnt, hctsiz->PKTCNT);
+        hctsiz->XFRSIZ -= MIN(actual, hctsiz->XFRSIZ);
         // hcdma += actual;
         // s->hreg1[index + 5] = hcdma;
 
-        if (!pcnt || len == 0 || actual == 0) {
+     if (hctsiz->PKTCNT == 0 || hctsiz->XFRSIZ == 0 || actual == 0) {
             done = true;
             // intr |= HCINTMSK_ACK;
         }
     } else {
         intr |= pintr[stsidx];
         if (p->packet.status == USB_RET_NAK &&
-            (eptype == USB_ENDPOINT_XFER_CONTROL ||
-             eptype == USB_ENDPOINT_XFER_BULK)) {
+            (hcchar->EPTYP == USB_ENDPOINT_XFER_CONTROL ||
+             hcchar->EPTYP == USB_ENDPOINT_XFER_BULK)) {
             /*
              * for ctrl/bulk, automatically retry on NAK,
              * but send the interrupt anyway
              */
             intr &= ~HCINTMSK_RESERVED14_31;
-            s->hreg1[index + 2] |= intr;
+            s->hreg_chan[chan].raw[R_HCINT] |= intr;
             do_intr = true;
         } else {
             intr |= HCINTMSK_CHHLTD;
@@ -483,29 +845,28 @@ babble:
     usb_packet_cleanup(&p->packet);
 
     if (done) {
-        hcchar &= ~HCCHAR_CHENA;
-        s->hreg1[index] = hcchar;
+        hcchar->CHENA = false;
         if (!(intr & HCINTMSK_CHHLTD)) {
             intr |= HCINTMSK_CHHLTD | HCINTMSK_XFERCOMPL;
         }
         intr &= ~HCINTMSK_RESERVED14_31;
-        s->hreg1[index + 2] |= intr;
+        s->hreg_chan[chan].raw[R_HCINT] |= intr;
         p->needs_service = false;
-        trace_usb_stm_packet_done(pstatus[stsidx], actual, len, pcnt);
+        trace_usb_stm_packet_done(pstatus[stsidx], actual, hctsiz->XFRSIZ, hctsiz->PKTCNT);
         STM32F4xx_update_hc_irq(s, index);
         return;
     }
 
     p->devadr = devadr;
-    p->epnum = epnum;
-    p->epdir = epdir;
-    p->mps = mps;
+    p->epnum = hcchar->EPNUM;
+    p->epdir = hcchar->EPDIR;
+    p->mps = hcchar->MPSIZ;
     p->pid = pid;
     p->index = index;
-    p->pcnt = pcnt;
-    p->len = len;
+    p->pcnt = hctsiz->PKTCNT;
+    p->len = hctsiz->XFRSIZ;
     p->needs_service = true;
-    trace_usb_stm_packet_next(pstatus[stsidx], len, pcnt);
+    trace_usb_stm_packet_next(pstatus[stsidx], hctsiz->XFRSIZ, hctsiz->PKTCNT);
     if (do_intr) {
         STM32F4xx_update_hc_irq(s, index);
     }
@@ -563,7 +924,8 @@ static void STM32F4xx_attach(USBPort *port)
     }
 
     s->fi = USB_FRMINTVL - 1;
-    s->hprt0 |= HPRT0_CONNDET | HPRT0_CONNSTS;
+    s->HPRT.PCDET = 1;
+    s->HPRT.PCSTS = 1;
 
     STM32F4xx_bus_start(s);
     STM32F4xx_raise_global_irq(s, GINTSTS_PRTINT);
@@ -577,9 +939,12 @@ static void STM32F4xx_detach(USBPort *port)
     assert(port->index == 0);
 
     STM32F4xx_bus_stop(s);
-
-    s->hprt0 &= ~(HPRT0_SPD_MASK | HPRT0_SUSP | HPRT0_ENA | HPRT0_CONNSTS);
-    s->hprt0 |= HPRT0_CONNDET | HPRT0_ENACHG;
+    s->HPRT.PSPD = 0;
+    s->HPRT.PSUSP = 0;
+    s->HPRT.PENA = 0;
+    s->HPRT.PCSTS = 0;
+    s->HPRT.PENCHNG = 1;
+    s->HPRT.PCDET = 0;
 
     STM32F4xx_raise_global_irq(s, GINTSTS_PRTINT);
 }
@@ -597,8 +962,8 @@ static void STM32F4xx_wakeup(USBPort *port)
     trace_usb_stm_wakeup(port);
     assert(port->index == 0);
 
-    if (s->hprt0 & HPRT0_SUSP) {
-        s->hprt0 |= HPRT0_RES;
+    if (s->HPRT.PSUSP) {
+        s->HPRT.PRST = 1;
         STM32F4xx_raise_global_irq(s, GINTSTS_PRTINT);
     }
 
@@ -720,37 +1085,31 @@ static void STM32F4xx_enable_chan(STM32F4xxUSBState *s,  uint32_t index)
 {
     USBDevice *dev;
     USBEndpoint *ep;
-    uint32_t hcchar;
-    uint32_t hctsiz;
-    uint32_t devadr, epnum, epdir, eptype, pid, len;
+    hcchar_t* hcchar;
+    hctsiz_t* hctsiz;
     STM32F4xxPacket *p;
 
-    assert((index >> 3) < STM32F4xx_NB_CHAN);
-    p = &s->packet[index >> 3];
-    hcchar = s->hreg1[index];
-    hctsiz = s->hreg1[index + 4];
-    devadr = get_field(hcchar, HCCHAR_DEVADDR);
-    epnum = get_field(hcchar, HCCHAR_EPNUM);
-    epdir = get_bit(hcchar, HCCHAR_EPDIR);
-    eptype = get_field(hcchar, HCCHAR_EPTYPE);
-    pid = get_field(hctsiz, TSIZ_SC_MC_PID);
-    len = get_field(hctsiz, TSIZ_XFERSIZE);
+    uint32_t chan = index>>3;
+    assert(chan < STM32F4xx_NB_CHAN);
+    hcchar = &s->hreg_chan[chan].defs.HCCHAR;
+    hctsiz = &s->hreg_chan[chan].defs.HCTSIZ;
+    p = &s->packet[chan];
 
-    dev = STM32F4xx_find_device(s, devadr);
+    dev = STM32F4xx_find_device(s, hcchar->DAD);
 
-    trace_usb_stm_enable_chan(index >> 3, dev, &p->packet, epnum);
+    trace_usb_stm_enable_chan(chan, dev, &p->packet, hcchar->EPNUM);
     if (dev == NULL) {
-        s->hreg1[index] &= ~HCCHAR_CHENA; // Disable channel if device not found.
+        hcchar->CHENA = false; // Disable channel if device not found.
         return;
     }
-
-    if (eptype == USB_ENDPOINT_XFER_CONTROL && pid == TSIZ_SC_MC_PID_SETUP) {
+    uint32_t pid;
+    if (hcchar->EPTYP == USB_ENDPOINT_XFER_CONTROL && hctsiz->DPID == TSIZ_SC_MC_PID_SETUP) {
         pid = USB_TOKEN_SETUP;
     } else {
-        pid = epdir ? USB_TOKEN_IN : USB_TOKEN_OUT;
+        pid = hcchar->EPDIR ? USB_TOKEN_IN : USB_TOKEN_OUT;
     }
 
-    ep = usb_ep_get(dev, pid, epnum);
+    ep = usb_ep_get(dev, pid, hcchar->EPNUM);
 
     /*
      * Hack: Networking doesn't like us delivering large transfers, it kind
@@ -758,13 +1117,13 @@ static void STM32F4xx_enable_chan(STM32F4xxUSBState *s,  uint32_t index)
      * size, we take that as a hint that this might be a network transfer,
      * and do the transfer packet-by-packet.
      */
-    if (len > 1536) {
+    if (hctsiz->XFRSIZ > 1536) {
         p->small = false;
     } else {
         p->small = true;
     }
 
-    STM32F4xx_handle_packet(s, devadr, dev, ep, index, true);
+    STM32F4xx_handle_packet(s, hcchar->DAD, dev, ep, index, true);
     qemu_bh_schedule(s->async_bh);
 }
 
@@ -794,7 +1153,7 @@ static uint64_t STM32F4xx_glbreg_read(void *ptr, hwaddr addr, int index,
         s->glbreg[index] = val;
         break;
     case GRXSTSP:
-        // printf("RX fifo pop (STSP): %08x @ %u\n", s->fifo_ram[s->rx_fifo_head], s->rx_fifo_head);
+        if (s->debug) printf("RX fifo pop (STSP): %08x @ %u\n", s->fifo_ram[s->rx_fifo_head], s->rx_fifo_head);
         if(s->rx_fifo_level>0) {
             val = s->fifo_ram[s->rx_fifo_head++];
             s->rx_fifo_level--;
@@ -818,35 +1177,28 @@ static void STM32F4xx_tx_packet(STM32F4xxUSBState *s, int index) {
 
     USBDevice *dev;
     USBEndpoint *ep;
-    uint32_t hcchar;
-    uint32_t hctsiz;
-    uint32_t devadr, epnum, epdir, eptype, pid, len;
     STM32F4xxPacket *p;
 
     assert((index >> 3) < STM32F4xx_NB_CHAN);
     p = &s->packet[index >> 3];
-    hcchar = s->hreg1[index];
-    hctsiz = s->hreg1[index + 4];
-    devadr = get_field(hcchar, HCCHAR_DEVADDR);
-    epnum = get_field(hcchar, HCCHAR_EPNUM);
-    epdir = get_bit(hcchar, HCCHAR_EPDIR);
-    eptype = get_field(hcchar, HCCHAR_EPTYPE);
-    pid = get_field(hctsiz, TSIZ_SC_MC_PID);
-    len = get_field(hctsiz, TSIZ_XFERSIZE);
 
-    dev = STM32F4xx_find_device(s, devadr);
+    hcchar_t* hcchar = &s->hreg_chan[index>>3].defs.HCCHAR;
+    hctsiz_t* hctsiz = &s->hreg_chan[index>>3].defs.HCTSIZ;
+
+    dev = STM32F4xx_find_device(s, hcchar->DAD);
 
     if (dev == NULL) {
         return;
     }
 
-    if (eptype == USB_ENDPOINT_XFER_CONTROL && pid == TSIZ_SC_MC_PID_SETUP) {
+    uint32_t pid;
+    if (hcchar->EPTYP == USB_ENDPOINT_XFER_CONTROL && hctsiz->DPID == TSIZ_SC_MC_PID_SETUP) {
         pid = USB_TOKEN_SETUP;
     } else {
-        pid = epdir ? USB_TOKEN_IN : USB_TOKEN_OUT;
+        pid = hcchar->EPDIR ? USB_TOKEN_IN : USB_TOKEN_OUT;
     }
 
-    ep = usb_ep_get(dev, pid, epnum);
+    ep = usb_ep_get(dev, pid, hcchar->EPNUM);
 
     /*
      * Hack: Networking doesn't like us delivering large transfers, it kind
@@ -854,13 +1206,13 @@ static void STM32F4xx_tx_packet(STM32F4xxUSBState *s, int index) {
      * size, we take that as a hint that this might be a network transfer,
      * and do the transfer packet-by-packet.
      */
-    if (len > 1536) {
+    if (hctsiz->XFRSIZ > 1536) {
         p->small = false;
     } else {
         p->small = true;
     }
 
-    STM32F4xx_handle_packet(s, devadr, dev, ep, index, true);
+    STM32F4xx_handle_packet(s, hcchar->DAD, dev, ep, index, true);
     qemu_bh_schedule(s->async_bh);
 }
 
@@ -923,6 +1275,12 @@ static void STM32F4xx_glbreg_write(void *ptr, hwaddr addr, int index, uint64_t v
             printf("FIXME: USB dma not implemented!\n");
         }
         break;
+    case GUSBCFG: 
+        if (val & GUSBCFG_FORCEDEVMODE) {
+            printf("USB OTG: Changing to device mode\n");
+            s->GINTSTS.CMOD = 0;
+        }
+        break;
     case GRSTCTL:
         val |= GRSTCTL_AHBIDLE;
         val &= ~GRSTCTL_DMAREQ;
@@ -955,7 +1313,7 @@ static void STM32F4xx_glbreg_write(void *ptr, hwaddr addr, int index, uint64_t v
                       GRSTCTL_IN_TKNQ_FLSH | GRSTCTL_FRMCNTRRST |
                       GRSTCTL_HSFTRST | GRSTCTL_CSFTRST);
         break;
-    case GINTSTS:
+    case R_GINTSTS*4:
         /* clear the write-1-to-clear bits */
         val |= ~old;
         val = ~val;
@@ -965,14 +1323,19 @@ static void STM32F4xx_glbreg_write(void *ptr, hwaddr addr, int index, uint64_t v
                       GINTSTS_GINNAKEFF | GINTSTS_NPTXFEMP | GINTSTS_RXFLVL |
                       GINTSTS_OTGINT | GINTSTS_CURMODE_HOST);
         iflg = 1;
+        if ((s->GINTSTS.USBRST && ((~val)&GINTSTS_USBRST)) && s->device_state==DEV_ST_RESET_WAIT) {
+            s->device_state = DEV_ST_SETUP;
+            STM32F4xx_cdc_schedule(s);
+        }
         break;
     case GINTMSK:
         iflg = 1;
         break;
-    case GRXFSIZ:
     case GRXSTSP:
     case GRXSTSR:
         printf("write to sts/siz\n");
+        /* FALLTHRU */
+    case GRXFSIZ:
         break;
     default:
         break;
@@ -1142,7 +1505,9 @@ static uint64_t STM32F4xx_hreg1_read(void *ptr, hwaddr addr, int index,
     uint32_t val;
 
     assert(addr >= HCCHAR(0) && addr <= HCDMAB(STM32F4xx_NB_CHAN - 1));
-    val = s->hreg1[index];
+    uint32_t chan = index >> 3;
+    uint32_t offset = index & 0b111;
+    val = s->hreg_chan[chan].raw[offset];
 
     //trace_usb_stm_hreg1_read(addr, hreg1nm[index & 7], addr >> 5, val);
     return val;
@@ -1159,8 +1524,10 @@ static void STM32F4xx_hreg1_write(void *ptr, hwaddr addr, int index, uint64_t va
     int enflg = 0;
     int disflg = 0;
 
+    uint32_t chan = index>>3;
+
     assert(addr >= HCCHAR(0) && addr <= HCDMAB(STM32F4xx_NB_CHAN - 1));
-    mmio = &s->hreg1[index];
+    mmio = &s->hreg_chan[chan].raw[index&0b111U];
     old = *mmio;
     uint64_t  HALT = HCCHAR_CHDIS | HCCHAR_CHENA;
     switch (HSOTG_REG(0x500) + (addr & 0x1c)) {
@@ -1197,7 +1564,7 @@ static void STM32F4xx_hreg1_write(void *ptr, hwaddr addr, int index, uint64_t va
             // but not for bulk endpoints though, it expects those to remain in NREADY
             if ((index>>3) == USB_ENDPOINT_XFER_BULK) {
                 s->is_ping = 0;
-                s->hreg1[index-2] &= (~HCCHAR_CHENA);
+                s->hreg_chan[chan].defs.HCCHAR.CHENA = false;
             } else {
                 old |= HCINTMSK_XFERCOMPL;
                 iflg = 1;
@@ -1227,7 +1594,7 @@ static void STM32F4xx_hreg1_write(void *ptr, hwaddr addr, int index, uint64_t va
 
     if (disflg) {
         /* set ChHltd in HCINT */
-        s->hreg1[(index & ~7) + 2] |= HCINTMSK_CHHLTD;
+        s->hreg_chan[chan].defs.HCINT.CHH = true;
         iflg = 1;
     }
 
@@ -1240,6 +1607,163 @@ static void STM32F4xx_hreg1_write(void *ptr, hwaddr addr, int index, uint64_t va
     }
 }
 
+static void STM32F4xx_dreg0_write(void *ptr, hwaddr addr, int index, uint64_t val,
+                             unsigned size)
+{
+    STM32F4xxUSBState *s = ptr;
+    //uint64_t orig = val;
+    //uint32_t *mmio;
+    uint32_t old;
+
+    old = s->dreg0[index];
+
+    uint32_t changed = old^val;
+
+    addr>>=2;
+
+    assert(addr >= R_DCFG && addr <= R_DIEPEMPMSK);
+    switch (addr){
+        case R_DCTL:
+            s->dreg0[index] = val;
+            if (changed&DCTL_SFTDISCON) {
+                //DC connected, start setup. 
+                if (s->dreg_defs.DCTL.SDIS) {
+                    s->device_state = DEV_ST_RESET;
+                } else {
+                    f4xx_usb_cdc_setup(s);
+                }
+            }
+        break;
+        case R_DOEPMSK:
+        case R_DIEPMSK:
+        case R_DAINTMSK:
+            s->dreg0[index] = val;
+            STM32F4xx_update_device_common_irq(s);
+            break;
+        case R_DIEPEMPMSK:
+            s->dreg0[index] = val;
+            break;
+        case R_DAINT:
+            qemu_log_mask(LOG_GUEST_ERROR,"Attempted to write read-only USB DAINT register!");
+            break;
+        default:
+            printf("unhandled USBD Write: %"PRIx64" to addr %"HWADDR_PRIx"\n", val, addr<<2);
+            break;
+    }
+
+}
+
+static uint64_t STM32F4xx_dreg0_read(void *ptr, hwaddr addr, int index,
+                                unsigned size)
+{
+    STM32F4xxUSBState *s = ptr;
+    uint32_t val;
+    addr >>=2;
+    assert(addr >= R_DCFG && addr <= R_DIEPEMPMSK);
+
+    val = s->dreg0[index];
+    //printf("DREG0 read: %"HWADDR_PRIx ": %"PRIx32" \n", addr<<2, val );
+    return val;
+}
+
+static uint64_t STM32F4xx_dregout_read(void *ptr, hwaddr addr, int index,
+                                unsigned size)
+{
+    STM32F4xxUSBState *s = ptr;
+    uint32_t chan = index>>3;
+    uint32_t offset = index & 0b111;
+    uint32_t val;
+    assert(chan<=4);
+    assert(offset <=0x20);
+
+    val = s->drego[chan].raw[offset];
+
+    if(s->debug && offset == R_OFF_DEPINT) printf("DREGout int read: %"HWADDR_PRIx ": %"PRIx32" \n", addr<<2, val );
+
+
+   // printf("DREGOUT read: %"HWADDR_PRIx ": %"PRIx32" \n", addr, val );
+    return val;
+}
+
+static void STM32F4xx_dregout_write(void *ptr, hwaddr addr, int index,
+                                 uint64_t val, unsigned size)
+{
+    STM32F4xxUSBState *s = ptr;
+    uint32_t chan = index>>3;
+    uint32_t offset = index & 0b111;
+    assert(chan<=4);
+    assert(offset <=0x20);
+    //printf("DREGOUT write: %"HWADDR_PRIx ": %"PRIx64" \n", addr, val );
+    switch (offset) {
+        case R_OFF_DEPCTL: // DIEPCTL
+            s->drego[chan].raw[offset] = val;
+            s->drego[chan].DOEPCTL.SNAK = 0;
+            s->drego[chan].DOEPCTL.CNAK = 0;
+            if (s->drego[chan].DOEPCTL.EPENA && s->device_state == DEV_ST_LINECODING){
+                s->device_state++;
+                STM32F4xx_cdc_schedule(s);
+            }
+            break;
+        case R_OFF_DEPINT: // DOEPINT
+            s->drego[chan].raw[offset] &= ~val;
+            STM32F4xx_update_device_common_irq(s);
+            break;
+        default:
+            s->drego[chan].raw[offset]= val;
+            break;
+    }
+}
+
+
+static uint64_t STM32F4xx_dregin_read(void *ptr, hwaddr addr, int index,
+                                unsigned size)
+{
+    STM32F4xxUSBState *s = ptr;
+    uint32_t chan = index>>3;
+    uint32_t offset = index & 0b111;
+    uint32_t val;
+    assert(chan<=4);
+    assert(offset <=0x20);
+
+    val = s->dregi[chan].raw[offset];
+    switch (offset) {
+        case R_OFF_DTXFSTS:
+            val = STM32F4xx_EP_FIFO_SIZE - s->fifo_level[chan];
+            break;
+    }
+
+    //printf("DREGIN read: %"HWADDR_PRIx ": %"PRIx32" \n", addr, val );
+    return val;
+}
+
+static void STM32F4xx_dregin_write(void *ptr, hwaddr addr, int index,
+                                 uint64_t val, unsigned size)
+{
+    STM32F4xxUSBState *s = ptr;
+    uint32_t chan = index>>3;
+    uint32_t offset = index & 0b111;
+    assert(chan<=4);
+    assert(offset <=0x20);
+    //printf("DREGIN write: %"HWADDR_PRIx ": %"PRIx64" \n", addr, val );
+    switch (offset) {
+        case R_OFF_DEPCTL: // DIEPCTL
+            s->dregi[chan].raw[offset] = val;
+            s->dregi[chan].DIEPCTL.SNAK = 0;
+            s->dregi[chan].DIEPCTL.CNAK = 0;
+            if (s->dregi[chan].DIEPCTL.EPENA)
+                STM32F4xx_cdc_schedule(s);
+            break;
+        case R_OFF_DEPINT: // DIEPINT
+            s->dregi[chan].raw[offset] &= ~val;
+            STM32F4xx_update_device_common_irq(s);
+            break;
+        default:
+            s->dregi[chan].raw[offset]= val;
+            break;
+    }
+
+}
+
 static const char *pcgregnm[] = {
         "PCGCTL   ", "PCGCCTL1 "
 };
@@ -1250,7 +1774,7 @@ static uint64_t STM32F4xx_pcgreg_read(void *ptr, hwaddr addr, int index,
     STM32F4xxUSBState *s = ptr;
     uint32_t val;
 
-    assert(addr >= PCGCTL && addr <= PCGCCTL1);
+    assert(addr>>2 >= R_PCGCTL && addr>>2 <= R_PCGCCTL1);
     val = s->pcgreg[index];
 
     trace_usb_stm_pcgreg_read(addr, pcgregnm[index], val);
@@ -1265,7 +1789,7 @@ static void STM32F4xx_pcgreg_write(void *ptr, hwaddr addr, int index,
     uint32_t *mmio;
     uint32_t old;
 
-    assert(addr >= PCGCTL && addr <= PCGCCTL1);
+    assert(addr>>2 >= R_PCGCTL && addr>>2 <= R_PCGCCTL1);
     mmio = &s->pcgreg[index];
     old = *mmio;
 
@@ -1294,8 +1818,16 @@ static uint64_t STM32F4xx_hsotg_read(void *ptr, hwaddr addr, unsigned size)
     case HSOTG_REG(0x500) ... HSOTG_REG(0x7fc):
         val = STM32F4xx_hreg1_read(ptr, addr, (addr - HSOTG_REG(0x500)) >> 2, size);
         break;
-    case HSOTG_REG(0x800) ... HSOTG_REG(0xdfc):
+    case HSOTG_REG(0x800) ... HSOTG_REG(0x834):
+        return STM32F4xx_dreg0_read(ptr, addr, (addr - HSOTG_REG(0x800)) >> 2, size);
+    case HSOTG_REG(0x900) ... HSOTG_REG(0x978):
+        return STM32F4xx_dregin_read(ptr, addr, (addr - HSOTG_REG(0x900)) >> 2, size);
+    case HSOTG_REG(0xB00) ... HSOTG_REG(0xB70):
+        return STM32F4xx_dregout_read(ptr, addr, (addr - HSOTG_REG(0xB00)) >> 2, size);
+    case HSOTG_REG(0x980) ... HSOTG_REG(0xAFC):
+    case HSOTG_REG(0xB74) ... HSOTG_REG(0xDFC):
         /* Gadget-mode registers, just return 0 for now */
+        printf("USBD READ: addr %"HWADDR_PRIx"\n", addr);
         val = 0;
         break;
     case HSOTG_REG(0xe00) ... HSOTG_REG(0xffc):
@@ -1327,7 +1859,18 @@ static void STM32F4xx_hsotg_write(void *ptr, hwaddr addr, uint64_t val,
     case HSOTG_REG(0x500) ... HSOTG_REG(0x7fc):
         STM32F4xx_hreg1_write(ptr, addr, (addr - HSOTG_REG(0x500)) >> 2, val, size);
         break;
-    case HSOTG_REG(0x800) ... HSOTG_REG(0xdfc):
+    case HSOTG_REG(0x800) ... HSOTG_REG(0x834):
+        STM32F4xx_dreg0_write(ptr, addr, (addr - HSOTG_REG(0x800)) >> 2, val, size);
+        break;
+    case HSOTG_REG(0x900) ... HSOTG_REG(0x978):
+        STM32F4xx_dregin_write(ptr, addr, (addr - HSOTG_REG(0x900)) >> 2,  val, size);
+        break;
+    case HSOTG_REG(0xB00) ... HSOTG_REG(0xB70):
+        STM32F4xx_dregout_write(ptr, addr,  (addr - HSOTG_REG(0xB00)) >> 2, val, size);
+        break;
+    case HSOTG_REG(0x980) ... HSOTG_REG(0xAFC):
+    case HSOTG_REG(0xB74) ... HSOTG_REG(0xdfc):
+        printf("USBD Write: %"PRIx64" to addr %"HWADDR_PRIx"\n", val, addr);
         /* Gadget-mode registers, do nothing for now */
         break;
     case HSOTG_REG(0xe00) ... HSOTG_REG(0xffc):
@@ -1356,10 +1899,10 @@ static uint64_t STM32F4xx_hreg2_read(void *ptr, hwaddr addr, unsigned size)
         s->rx_fifo_head %= STM32F4xx_RX_FIFO_SIZE;
         s->rx_fifo_level--;
         if (s->rx_fifo_level == 0) {
-            s->gintsts &= ~GINTSTS_RXFLVL;
+            s->GINTSTS.RXFLVL = 0;
             STM32F4xx_update_irq(s);
         }
-        // printf("FIFO read: %08x (L: %u H: %u T: %u)\n",value, s->rx_fifo_level, s->rx_fifo_head, s->rx_fifo_tail);
+        if (s->debug) printf("FIFO read: %08x (L: %u H: %u T: %u)\n",value, s->rx_fifo_level, s->rx_fifo_head, s->rx_fifo_tail);
     }
     // trace_usb_stm_hreg2_read(addr, addr >> 12, value);
     // qemu_log_mask(LOG_GUEST_ERROR, "FIFO read not implemented\n");
@@ -1383,18 +1926,30 @@ static void STM32F4xx_hreg2_write(void *ptr, hwaddr addr, uint64_t val,
     s->fifo_tail[index] %= STM32F4xx_EP_FIFO_SIZE;
     s->fifo_level[index]++;
     assert(s->fifo_tail[index]<STM32F4xx_EP_FIFO_SIZE); // laziness ftw
-    uint32_t txsize = s->hctsiz(index);
-    uint32_t bytes_needed = get_field(txsize, TSIZ_XFERSIZE);
+    uint32_t bytes_needed;
+    int packets_left;
+    if (s->GINTSTS.CMOD) {
+        packets_left = s->hreg_chan[index].defs.HCTSIZ.PKTCNT;
+        bytes_needed =  s->hreg_chan[index].defs.HCTSIZ.XFRSIZ;
+    } else {
+        packets_left = s->dregi[index].DIEPTSIZ.PKTCNT;
+        bytes_needed = s->dregi[index].DIEPTSIZ.XFRSIZ;
+    }
+
     int words_needed = (bytes_needed >> 2);
     if (bytes_needed % 4 !=0)
     {
         words_needed++;
     }
-    int packets_left = get_field(txsize, TSIZ_PKTCNT);
     if ( (s->fifo_level[index]) >= words_needed && packets_left>0) {
         // Enough data written to do a transfer...
-        // printf("Data ready for tx on %u\n", index);
-        STM32F4xx_tx_packet(s, index<<3);
+        printf("Data ready for tx on %u\n", index);
+        if (s->device_state == DEV_ST_RESET) {
+            // NOT CDC hack
+            STM32F4xx_tx_packet(s, index<<3);
+        } else {
+            STM32F4xx_cdc_schedule(s);
+        }
     }
 }
 
@@ -1455,8 +2010,11 @@ static void STM32F4xx_reset_enter(Object *obj, ResetType type)
     s->gahbcfg = 0;
     s->gusbcfg = 5 << GUSBCFG_USBTRDTIM_SHIFT;
     s->grstctl = GRSTCTL_AHBIDLE;
-    s->gintsts = GINTSTS_CONIDSTSCHNG | GINTSTS_PTXFEMP | GINTSTS_NPTXFEMP |
-                 GINTSTS_CURMODE_HOST;
+    s->gintsts = 0;
+    s->GINTSTS.NPTXFE = 1;
+    s->GINTSTS.PTXFE = 1;
+    s->GINTSTS.CIDSCHG = 1;
+    s->GINTSTS.CMOD = 1;
     s->gintmsk = 0;
     s->grxstsr = 0;
     s->grxstsp = 0;
@@ -1551,7 +2109,8 @@ static void STM32F4xx_reset_exit(Object *obj)
         c->parent_phases.exit(obj);
     }
 
-    s->hprt0 = HPRT0_PWR;
+    s->hprt0 = 0;
+    s->HPRT.PPWR = 1;
     if (s->uport.dev && s->uport.dev->attached) {
         usb_attach(&s->uport);
         usb_device_reset(s->uport.dev);
@@ -1599,17 +2158,39 @@ static void STM32F4xx_realize(DeviceState *dev, Error **errp)
     s->fi = USB_FRMINTVL - 1;
     s->eof_timer = timer_new_ns(QEMU_CLOCK_VIRTUAL, STM32F4xx_frame_boundary, s);
     s->frame_timer = timer_new_ns(QEMU_CLOCK_VIRTUAL, STM32F4xx_work_timer, s);
+    s->cdc_timer = timer_new_us(QEMU_CLOCK_VIRTUAL, STM32F4xx_cdc_helper, s);
     s->async_bh = qemu_bh_new(STM32F4xx_work_bh, s);
 
     qdev_init_gpio_in_named(dev,stm32f4xx_usb_reset,"rcc-reset",1);
 
     sysbus_init_irq(sbd, &s->irq);
+
+    qemu_chr_fe_set_handlers(&s->cdc, f4xx_usb_cdc_can_receive, f4xx_usb_cdc_receive, NULL,
+            NULL,s,NULL,true);
+    qemu_chr_fe_set_echo(&s->cdc, true);
 }
 
 static void STM32F4xx_init(Object *obj)
 {
     SysBusDevice *sbd = SYS_BUS_DEVICE(obj);
     STM32F4xxUSBState *s = STM32F4xx_USB(obj);
+
+    CHECK_ALIGN(sizeof(s->hreg1), sizeof(s->hreg_chan), "hreg_raw");
+    CHECK_ALIGN(sizeof(((hreg_set_t*)0)->defs), sizeof(((hreg_set_t*)0)->raw), "RAW");
+    CHECK_REG_u32(s->GINTSTS);
+    //CHECK_ALIGN(sizeof(s->dreg0), sizeof(s->dreg_defs), "Common Dev Regs");
+    CHECK_REG_u32(s->dreg_defs.DCFG);
+    CHECK_REG_u32(s->dreg_defs.DCTL);
+    CHECK_REG_u32(s->dreg_defs.DAINT);
+
+
+    CHECK_TYPEDEF_u32(hreg_set_t,defs.HCCHAR);
+    CHECK_TYPEDEF_u32(hreg_set_t,defs.HCSPLT);
+    CHECK_TYPEDEF_u32(hreg_set_t,defs.HCINT);
+    CHECK_TYPEDEF_u32(hreg_set_t,defs.HCINTMSK);
+    CHECK_TYPEDEF_u32(hreg_set_t,defs.HCTSIZ);
+    CHECK_TYPEDEF_u32(hreg_set_t,defs.HCDMA);
+
 
     memory_region_init(&s->container, obj, "STM32F4xx", STM32F4xx_MMIO_SIZE);
     sysbus_init_mmio(sbd, &s->container);
@@ -1626,6 +2207,11 @@ static void STM32F4xx_init(Object *obj)
     //                       "STM32F4xx-dbg", 0x1FFFF);
     // memory_region_add_subregion(&s->container, 0x20000, &s->dma_mr);
     //memory_region_init_io(&s->dma_mr, obj, NULL, s, "f4xx-usb.dma", 0x1FFFF);
+
+    // printf("Starting USB IP thread...\n");
+    // pthread_create(&s->usbip_thread, NULL, usbip_run, NULL);
+
+
 }
 
 static const VMStateDescription vmstate_STM32F4xx_state_packet = {
@@ -1660,7 +2246,7 @@ const VMStateDescription vmstate_STM32F4xx_state = {
         VMSTATE_UINT32_ARRAY(hreg0, STM32F4xxUSBState,
                              STM32F4xx_HREG0_SIZE / sizeof(uint32_t)),
         VMSTATE_UINT32_ARRAY(hreg1, STM32F4xxUSBState,
-                             STM32F4xx_HREG1_SIZE / sizeof(uint32_t)),
+                             STM32F4xx_NB_CHAN*R_HREG_MAX),
         VMSTATE_UINT32_ARRAY(pcgreg, STM32F4xxUSBState,
                              STM32F4xx_PCGREG_SIZE / sizeof(uint32_t)),
 
@@ -1694,6 +2280,7 @@ const VMStateDescription vmstate_STM32F4xx_state = {
 
 static Property STM32F4xx_usb_properties[] = {
     DEFINE_PROP_UINT32("usb_version", STM32F4xxUSBState, usb_version, 2),
+    DEFINE_PROP_CHR("chardev", STM32F4xxUSBState, cdc),
     DEFINE_PROP_END_OF_LIST(),
 };
 

--- a/hw/arm/prusa/stm32f407/stm32f4xx_usb.c
+++ b/hw/arm/prusa/stm32f407/stm32f4xx_usb.c
@@ -45,7 +45,6 @@
 #include "qemu/error-report.h"
 #include "qemu/main-loop.h"
 #include "hw/qdev-properties.h"
-#include "usbip.h"
 
 #define USB_HZ_FS       12000000
 #define USB_HZ_HS       96000000 // was 96, this might be wrong but STM clocks usb at 48 mhz

--- a/hw/arm/prusa/stm32f407/stm32f4xx_usb.h
+++ b/hw/arm/prusa/stm32f407/stm32f4xx_usb.h
@@ -228,7 +228,7 @@ typedef union {
         uint32_t _unused; // 0x518 Padding (HCDMAB on DWC2)
         uint32_t _unused2; // 0x51C padding
     }defs;
-} QEMU_PACKED hreg_set_t;
+} hreg_set_t;
 
 struct STM32F4xxUSBState {
     /*< private >*/

--- a/hw/arm/prusa/stm32f407/stm32f4xx_usb.h
+++ b/hw/arm/prusa/stm32f407/stm32f4xx_usb.h
@@ -564,7 +564,7 @@ struct STM32F4xxUSBState {
 
     uint8_t device_state;
 
-    pthread_t usbip_thread;
+    //pthread_t usbip_thread;
 
     bool debug;
 

--- a/hw/arm/prusa/stm32f407/stm32f4xx_usb.h
+++ b/hw/arm/prusa/stm32f407/stm32f4xx_usb.h
@@ -22,16 +22,21 @@
 
 #include "qemu/timer.h"
 #include "hw/irq.h"
+#include "chardev/char-fe.h"
+#include "chardev/char.h"
 #include "hw/sysbus.h"
 #include "hw/usb.h"
 #include "sysemu/dma.h"
 #include "qemu/units.h"
 #include "qom/object.h"
+#include "hw/qdev-properties-system.h"
+#include "../utility/macros.h"
 
 #define STM32F4xx_MMIO_SIZE      0xCFFF // CSRs and FIFOs
 
 #define STM32F4xx_NB_CHAN        16       /* Number of host channels */
 // N.B - device has max 12, but the LL HAL code resets up to 16 (likely for other device compat)
+#define STM32F4xx_NB_DEVCHAN        4       /* Number of device-mode channels */
 #define STM32F4xx_MAX_XFER_SIZE  65536   /* Max transfer size expected in HCTSIZ */
 
 #define STM32F4xx_EP_FIFO_SIZE 4*KiB / sizeof(uint32_t)
@@ -40,6 +45,8 @@
 typedef struct STM32F4xxPacket STM32F4xxPacket;
 typedef struct STM32F4xxUSBState STM32F4xxUSBState;
 typedef struct STM32F4xxClass STM32F4xxClass;
+
+#define R_HREG_MAX (0x20/4)
 
 enum async_state {
     STM32F4xx_ASYNC_NONE = 0,
@@ -73,6 +80,156 @@ typedef union {
     } QEMU_PACKED;
 } rxstatus_t;
 
+typedef struct {
+    uint32_t XFRSIZ :19;
+    uint32_t PKTCNT :10;
+    uint32_t DPID :2;
+    uint32_t DOPING :1;
+} QEMU_PACKED hctsiz_t;
+
+typedef struct {
+    uint32_t MPSIZ :11;
+    uint32_t EPNUM :4;
+    uint32_t EPDIR :1;
+    uint32_t :1;
+    uint32_t LSDEV :1;
+    uint32_t EPTYP :2;
+    uint32_t MCNT :2;
+    uint32_t DAD :7;
+    uint32_t ODDFRM :1;
+    uint32_t CHDIS :1;
+    uint32_t CHENA :1;
+} QEMU_PACKED hcchar_t;
+
+typedef struct {
+    uint32_t MPSIZ :11;
+    uint32_t _reserved :4;
+    REG_B32(USBAEP);
+    REG_B32(EONUMDPID);
+    REG_B32(NAKSTS);
+    uint32_t EPTYP :2;
+    REG_B32(DO_SNPM);
+    REG_B32(STALL);
+    uint32_t DI_TXFNUM :4;
+    REG_B32(CNAK);
+    REG_B32(SNAK);
+    REG_B32(SD0PID);
+    REG_B32(SODDFRM);
+    REG_B32(EPDIS);
+    REG_B32(EPENA);
+} QEMU_PACKED depctl_t; 
+
+typedef struct {
+    REG_B32(XFRC);
+    REG_B32(EPDISD);
+    REG_B32(_reserved);
+    REG_B32(TOC);
+    REG_B32(ITTXFE);
+    REG_B32(INEPNM);
+    REG_B32(INEPNE);
+    REG_B32(TXFE);
+    uint32_t _reserved2 :3;
+    REG_B32(PKTDRPSTS);
+    REG_B32(_reserved3);
+    REG_B32(NAK);
+    uint32_t :18;
+} QEMU_PACKED diepint_t;
+
+typedef struct {
+    REG_B32(XFRC);
+    REG_B32(EPDISD);
+    REG_B32(_reserved);
+    REG_B32(STUP);
+    REG_B32(OTEPDIS);
+    REG_B32(STSPHSRX);
+    uint32_t _reserved2 :2;
+    REG_B32(OUTPKTERR);
+    uint32_t _reserved3 :3;
+    REG_B32(BERR);
+    REG_B32(NAK);
+    uint32_t :18;
+} QEMU_PACKED doepint_t;
+
+typedef struct {
+    uint32_t XFRSIZ :19;
+    uint32_t PKTCNT :10;
+    uint32_t DO_RXPID_STUPCNT :2;
+    uint32_t :1;
+} QEMU_PACKED deptsiz_t;
+
+typedef union {
+    struct {
+        depctl_t DIEPCTL; // 0x900
+        uint32_t _unused;  // 0x904
+        doepint_t DIEPINT; // 0x908
+        uint32_t _unused2; // 0x90C
+        deptsiz_t DIEPTSIZ; // 0x910
+        uint32_t _unused3;// 0x914
+        REG_S32(INEPTSFSAV,16); // 0x918
+        uint32_t _unused4;// 0x91c
+    };
+    uint32_t raw[8];
+} QEMU_PACKED dreg_di_set_t;
+
+typedef union {
+    struct {
+        depctl_t DOEPCTL; // 0xB00
+        uint32_t _unused;  // 0xB04
+        doepint_t DOEPINT; // 0xB08
+        uint32_t _unused2;
+        deptsiz_t DIEPTSIZ; // 0xB10
+        uint32_t _unused4[3];// 0xB14 - 0xB1C
+    }; 
+    uint32_t raw[8];
+} QEMU_PACKED dreg_do_set_t;
+
+typedef union {
+    uint32_t raw[R_HREG_MAX];
+    struct {
+        hcchar_t HCCHAR; // 0x500
+        struct {
+            uint32_t PRTADDR :7;
+            uint32_t HUBADDR :7;
+            uint32_t XACTPOS :2;
+            REG_B32(COMPLSPLT);
+            uint32_t :14;
+            REG_B32(SPLTEN);
+        } QEMU_PACKED HCSPLT; // 0x504
+        struct {
+            REG_B32(XFRC);
+            REG_B32(CHH);
+            REG_B32(_reserved);
+            REG_B32(STALL);
+            REG_B32(NAK);
+            REG_B32(ACK);
+            REG_B32(_reserved2);
+            REG_B32(TXERR);
+            REG_B32(BBERR);
+            REG_B32(FRMOR);
+            REG_B32(DTERR);
+            uint32_t :21;
+        } QEMU_PACKED HCINT; // 0x508
+        struct {
+            REG_B32(XFRCM);
+            REG_B32(CHHM);
+            REG_B32(_reserved);
+            REG_B32(STALLM);
+            REG_B32(NAKM);
+            REG_B32(ACKM);
+            REG_B32(_reserved2);
+            REG_B32(TXERRM);
+            REG_B32(BBERRM);
+            REG_B32(FRMORM);
+            REG_B32(DTERRM);
+            uint32_t :21;
+        } QEMU_PACKED HCINTMSK; // 0x50C
+        hctsiz_t HCTSIZ;    // 0x510
+        uint32_t HCDMA;     // 0x514
+        uint32_t _unused; // 0x518 Padding (HCDMAB on DWC2)
+        uint32_t _unused2; // 0x51C padding
+    }defs;
+} QEMU_PACKED hreg_set_t;
+
 struct STM32F4xxUSBState {
     /*< private >*/
     SysBusDevice parent_obj;
@@ -95,8 +252,41 @@ struct STM32F4xxUSBState {
             uint32_t gahbcfg;       /* 08 */
             uint32_t gusbcfg;       /* 0c */
             uint32_t grstctl;       /* 10 */
-            uint32_t gintsts;       /* 14 */
-            uint32_t gintmsk;       /* 18 */
+            union {
+                uint32_t gintsts;       /* 14 */
+                struct {
+                    REG_B32(CMOD);
+                    REG_B32(MMIS);
+                    REG_B32(OTGINT);
+                    REG_B32(SOF);
+                    REG_B32(RXFLVL);
+                    REG_B32(NPTXFE);
+                    REG_B32(GINAKEFF);
+                    REG_B32(GONAKEFF);
+                    uint32_t _reserved :2;
+                    REG_B32(ESUSP);
+                    REG_B32(USBSUSP);
+                    REG_B32(USBRST);
+                    REG_B32(ENUMDNE);
+                    REG_B32(ISOODRP);
+                    REG_B32(EOPF);
+                    uint32_t _reserved2 :2;
+                    REG_B32(IEPINT);
+                    REG_B32(OEPINT);
+                    REG_B32(ISOIXFR);
+                    REG_B32(IPXFR);
+                    uint32_t _reserved3 :2;
+                    REG_B32(HPRTINT);
+                    REG_B32(HCINT);
+                    REG_B32(PTXFE);
+                    REG_B32(_reserved4);
+                    REG_B32(CIDSCHG);
+                    REG_B32(DISCINT);
+                    REG_B32(SRQINT);
+                    REG_B32(WKUINT);
+                } QEMU_PACKED GINTSTS;
+            };
+            uint32_t gintmsk;       /* 18 */   
             union {
                 uint32_t grxstsr;       /* 1c */
                 rxstatus_t defs;
@@ -151,20 +341,36 @@ struct STM32F4xxUSBState {
             uint32_t haintmsk;      /* 418 */
             uint32_t hflbaddr;      /* 41c */
             uint32_t rsvd1[8];      /* 420-43c */
-            uint32_t hprt0;         /* 440 */
+            union {
+                struct {
+                    REG_B32(PCSTS);
+                    REG_B32(PCDET);
+                    REG_B32(PENA);
+                    REG_B32(PENCHNG);
+                    REG_B32(POCA);
+                    REG_B32(POCCHNG);
+                    REG_B32(PRES);
+                    REG_B32(PSUSP);
+                    REG_B32(PRST);
+                    REG_B32(_reserved);
+                    uint32_t PLSTS :2;
+                    REG_B32(PPWR);
+                    uint32_t PTCTL :4;
+                    uint32_t PSPD :2;
+                    uint32_t :13;
+                } QEMU_PACKED HPRT;
+                uint32_t hprt0;         /* 440 */
+            };
         };
     };
 
-#define STM32F4xx_HREG1_SIZE     (0x20 * STM32F4xx_NB_CHAN)
-    uint32_t hreg1[STM32F4xx_HREG1_SIZE / sizeof(uint32_t)];
+    union {
+        uint32_t hreg1[STM32F4xx_NB_CHAN*R_HREG_MAX];
+        hreg_set_t hreg_chan[STM32F4xx_NB_CHAN];
+    };
 
-#define hcchar(_ch)     hreg1[((_ch) << 3) + 0] /* 500, 520, ... */
-#define hcsplt(_ch)     hreg1[((_ch) << 3) + 1] /* 504, 524, ... */
-#define hcint(_ch)      hreg1[((_ch) << 3) + 2] /* 508, 528, ... */
-#define hcintmsk(_ch)   hreg1[((_ch) << 3) + 3] /* 50c, 52c, ... */
-#define hctsiz(_ch)     hreg1[((_ch) << 3) + 4] /* 510, 530, ... */
-#define hcdma(_ch)      hreg1[((_ch) << 3) + 5] /* 514, 534, ... */
-#define hcdmab(_ch)     hreg1[((_ch) << 3) + 7] /* 51c, 53c, ... */
+#define STM32F4xx_HREG1_SIZE     (0x20 * STM32F4xx_NB_CHAN)
+    // uint32_t hreg1[STM32F4xx_HREG1_SIZE / sizeof(uint32_t)];
 
     union {
 #define STM32F4xx_PCGREG_SIZE    0x08
@@ -175,6 +381,149 @@ struct STM32F4xxUSBState {
         };
     };
 
+// Device mode register definitions.
+    union {
+        uint32_t dreg0[0x84];
+        struct {
+            struct {
+                uint32_t DSPD :2;
+                REG_B32(NZLSOHSK);
+                REG_B32(_reserved);
+                uint32_t DAD :7;
+                uint32_t PFLVL :2;
+                uint32_t _reserved2 :11;
+                uint32_t PERSCHVL :2;
+                uint32_t :6;
+            } QEMU_PACKED DCFG; // 0x800
+            struct {
+                REG_B32(RWUSIG);
+                REG_B32(SDIS);
+                REG_B32(GINSTS);
+                REG_B32(GONSTS);
+                uint32_t TCTL :3;
+                REG_B32(SGINAK);
+                REG_B32(CGINAK);
+                REG_B32(SGONAK);
+                REG_B32(CGONAK);
+                REG_B32(POPRGDNE);
+                uint32_t :20;
+            } QEMU_PACKED DCTL; // 0x804
+            struct {
+                REG_B32(SUSPSTS);
+                uint32_t ENUMSPD :2;
+                REG_B32(EERR);
+                uint32_t _unused :4;
+                uint32_t FNSOF :14;
+                uint32_t :10;
+            } QEMU_PACKED DSTS; // 0x808
+            uint32_t _unusedl; // 0x80C
+            struct {
+                REG_B32(XFRCM);
+                REG_B32(EPDM);
+                REG_B32(AHBERRM);
+                REG_B32(TOM);
+                REG_B32(ITTXFEMSK);
+                REG_B32(INEPNMM);
+                REG_B32(INEPNEM);
+                REG_B32(_reserved);
+                REG_B32(TXFURM);
+                uint32_t _reserved2 :4;
+                REG_B32(NAKM);
+                uint32_t :18;
+            } QEMU_PACKED DIEPMSK; // 0x810
+            struct {
+                REG_B32(XFRCM);
+                REG_B32(EPDM);
+                REG_B32(AHBERRM);
+                REG_B32(STUPM);
+                REG_B32(OTEPDM);
+                REG_B32(STSPHSRXM);
+                REG_B32(B2BSTIP);
+                REG_B32(_reserved);
+                REG_B32(OPEM);
+                uint32_t _reserved2 :3;
+                REG_B32(BERRM);
+                REG_B32(NAKMSK);
+                REG_B32(NYETMSK);
+                uint32_t :17;
+            } QEMU_PACKED DOEPMSK; // 0x814
+            struct {
+                uint32_t IEPINT :16;
+                uint32_t OEPINT :16;
+            } QEMU_PACKED DAINT; // 0x818
+            struct {
+                uint32_t IEPM :16;
+                uint32_t OEPM :16;
+            } QEMU_PACKED DAINTMSK; // 0x81C
+            uint32_t _unused2[2]; // 0x820-4
+            REG_S32(VBUSDT,16); // 0x828
+            REG_S32(DVBUSP, 12); // 0x82C
+            struct {
+                REG_B32(NONISOTHREN);
+                REG_B32(ISOTHREN);
+                uint32_t TXTHRLEN :9;
+                uint32_t _reserved :5;
+                REG_B32(RXTHREN);
+                uint32_t RXTHRLEN :9;
+                REG_B32(_reserved2);
+                REG_B32(ARPEN);
+                uint32_t :4;
+            } QEMU_PACKED DTHRCTRL; // 0x830;
+            REG_S32(INEPTXFEM, 16); // 0x834;
+            struct {
+                REG_B32(_reserved);
+                REG_B32(IEP1INT);
+                uint32_t _reserved2 :15;
+                REG_B32(OEP1INT);
+                uint32_t :14;
+            } QEMU_PACKED DEACHINT; // 0x838
+            struct {
+                REG_B32(_reserved);
+                REG_B32(IEP1INTM);
+                uint32_t _reserved2 :15;
+                REG_B32(OEP1INTM);
+                uint32_t :14;
+            } QEMU_PACKED DEACHINTMSK; // 0x83C
+            uint32_t _unused3; // 0x840
+            struct {
+                REG_B32(XFRCM);
+                REG_B32(EPDM);
+                REG_B32(AHBERRM);
+                REG_B32(TOM);
+                REG_B32(ITTXFEMSK);
+                REG_B32(INEPNMM);
+                REG_B32(INEPNEM);
+                REG_B32(_reserved);
+                REG_B32(TXFURM);
+                REG_B32(BIM);
+                uint32_t _reserved2 :3;
+                REG_B32(NAKM);
+                uint32_t :18;
+            } QEMU_PACKED DIEPEACHMSK1; // 0x844
+            uint32_t _reserved[0x20/4];
+            struct {
+                REG_B32(XFRCM);
+                REG_B32(EPDM);
+                REG_B32(AHBERRM);
+                REG_B32(TOM);
+                 REG_B32(ITTXFEMSK);
+                REG_B32(INEPNMM);
+                REG_B32(INEPNEM);
+                REG_B32(_reserved);
+                REG_B32(TXFURM);
+                REG_B32(BIM);
+                uint32_t _reserved2 :3;
+                REG_B32(BERRM);
+                REG_B32(NAKMSK);
+                REG_B32(NYETM);
+                uint32_t :17;
+            } QEMU_PACKED DOEPEACHMSK1; // 0x884
+        } QEMU_PACKED dreg_defs;
+    };
+
+    dreg_di_set_t dregi[STM32F4xx_NB_DEVCHAN];
+    dreg_do_set_t drego[STM32F4xx_NB_DEVCHAN];
+
     /* TODO - implement FIFO registers for slave mode */
 #define STM32F4xx_HFIFO_SIZE     (0x1000 * STM32F4xx_NB_CHAN)
 
@@ -183,6 +532,7 @@ struct STM32F4xxUSBState {
      */
     QEMUTimer *eof_timer;
     QEMUTimer *frame_timer;
+    QEMUTimer *cdc_timer;
     QEMUBH *async_bh;
     int64_t sof_time;
     int64_t usb_frame_time;
@@ -211,6 +561,16 @@ struct STM32F4xxUSBState {
     uint32_t rx_fifo_tail;
     uint32_t rx_fifo_level;
     uint8_t is_ping;
+
+    uint8_t device_state;
+
+    pthread_t usbip_thread;
+
+    bool debug;
+
+    char cdc_in;
+
+    CharBackend cdc;
 
 };
 

--- a/hw/arm/prusa/utility/macros.h
+++ b/hw/arm/prusa/utility/macros.h
@@ -63,6 +63,7 @@
 #define CHECK_PRI(x,y)  #x" != "#y                      
 #define CHECK_ALIGN(x,y, name) static_assert(x == y, "ERROR - " name " register definition misaligned! - " CHECK_PRI(x,y))
 #define CHECK_REG_u32(reg) CHECK_ALIGN(sizeof(reg),sizeof(uint32_t),#reg " size incorrect!")
+#define CHECK_TYPEDEF_u32(type,reg) CHECK_ALIGN(sizeof(((type*)0)->reg),sizeof(uint32_t),#reg " size incorrect!")
 
 #define REG_S32(name,used) struct{ uint32_t name :used; uint32_t :32-used; } QEMU_PACKED 
 #define REG_B32(name) uint32_t name :1


### PR DESCRIPTION
### Description

Adds a fake USB CDC option that can be used via a standard QEMU chardev.

### Behaviour/ Breaking changes

Should not break anything, only adds functionality. 

### Have you tested the changes?

Yes, appears to work locally. 

### Other

Still pretty rough around the edges with some of the direct IRQ hacking in cdc_setup. 

Longer term... see if it's worth supporting USBIP directly so device-mode guests can be connected to the host. 

### Linked issues:

 - Partial for #29 (TBD whether I split off the USBIP component or do it in this branch too.)
