### PR TITLE
Fix #86 - ethernet not working

### DIFF
--- a/hw/arm/prusa/stm32f407/stm32f4xx_eth.c
+++ b/hw/arm/prusa/stm32f407/stm32f4xx_eth.c
@@ -39,6 +39,7 @@
 #include "net/net.h"
 #include "hw/net/mii.h"
 #include "qom/object.h"
+#include "../utility/macros.h"
 
 #ifdef DEBUG_STM32F4XXETH
 #define DEBUGF_BRK(message, args...) do { \
@@ -173,9 +174,11 @@ struct Stm32F4xx_Eth {
             struct {
                 uint32_t    MB :1;
                 uint32_t    MW :1;
-                uint32_t    CR :4;
+                uint32_t    CR :3;
+                REG_B32(_unused);
                 uint32_t    MR :5;
                 uint32_t    PA :5;
+                uint32_t    :16;
             } QEMU_PACKED MACMIIAR;
             struct {
                 uint32_t    MD :16;
@@ -463,6 +466,9 @@ static void stm32f4xx_eth_realize(DeviceState *dev, Error **errp)
 {
     SysBusDevice *sbd = SYS_BUS_DEVICE(dev);
     Stm32F4xx_Eth *s = STM32F4XXETH(dev);
+
+    CHECK_REG_u32(s->defs.MACMIIAR);
+    CHECK_REG_u32(s->defs.MACMIIDR);
 
     memory_region_init_io(&s->iomem, OBJECT(s), &enet_mem_ops, s,
                           "stm32-eth", 0x1400);


### PR DESCRIPTION
### Description

Fixes a networking bug

### Behaviour/ Breaking changes

ETH MACMIIAR definition was malformed, when a packing directive was added it caused a misalignment that resulted in the HAL never seeing the link go up. 

### Have you tested the changes?

Yes - can now access localhost:3333 and get the web UI again.

### Other

Use the bloody CHECK_REG_* macros, you doofus!

### Linked issues:

 - Fixes #86 
