### PR TITLE
Set correct number of NVIC priority bits for stm32f407

### DIFF
--- a/hw/arm/prusa/meson.build
+++ b/hw/arm/prusa/meson.build
@@ -41,3 +41,7 @@ arm_ss.add(when: 'CONFIG_BUDDYBOARD', if_true: files(
         'utility/p404_script_console.c',
         'utility/p404scriptable.c',
     ))
+
+# Use CONFIG_PRUSA_STM32_HACKS when building our target to enable our specific workarounds
+prusa_hacks = declare_dependency(compile_args: '-DCONFIG_PRUSA_STM32_HACKS')
+arm_ss.add(when: 'CONFIG_BUDDYBOARD', if_true: [prusa_hacks])

--- a/hw/arm/prusa/meson.build
+++ b/hw/arm/prusa/meson.build
@@ -20,13 +20,9 @@ if libglut.found() and libglu.found() and libglew.found() and libgl.found()
     subdir('assets')
 else
     message('OpenGL libraries not found. Install development packages for freeglut, glew, and mesa and re-run configure.')
-
 endif
 
-
-
 subdir('stm32f407')
-
 
 arm_ss.add(when: 'CONFIG_BUDDYBOARD', if_true: files(
         'prusa-mini.c',
@@ -45,6 +41,3 @@ arm_ss.add(when: 'CONFIG_BUDDYBOARD', if_true: files(
         'utility/p404_script_console.c',
         'utility/p404scriptable.c',
     ))
-
-# Required if using Message queue IPC
-

--- a/hw/intc/armv7m_nvic.c
+++ b/hw/intc/armv7m_nvic.c
@@ -2834,7 +2834,13 @@ static void armv7m_nvic_realize(DeviceState *dev, Error **errp)
     /* include space for internal exception vectors */
     s->num_irq += NVIC_FIRST_IRQ;
 
+#ifdef CONFIG_PRUSA_STM32_HACKS
+    // TODO: change to a priority to be overridden in the final target
+    // as done for num-irq above
+    s->num_prio_bits = 4;
+#else
     s->num_prio_bits = arm_feature(&s->cpu->env, ARM_FEATURE_V7) ? 8 : 2;
+#endif
 
     if (!sysbus_realize(SYS_BUS_DEVICE(&s->systick[M_REG_NS]), errp)) {
         return;

--- a/hw/usb/bus.c
+++ b/hw/usb/bus.c
@@ -444,14 +444,15 @@ void usb_claim_port(USBDevice *dev, Error **errp)
         }
     } else {
         // HACK ALERT - disable addition of hubs, mini doesn't like them!
-        fprintf(stderr,"FIXME: Clean up auto-add hub hack!\n");
-        if (false && bus->nfree == 1 && strcmp(object_get_typename(OBJECT(dev)), "usb-hub") != 0) {
+#ifndef CONFIG_PRUSA_STM32_HACKS
+        if (bus->nfree == 1 && strcmp(object_get_typename(OBJECT(dev)), "usb-hub") != 0) {
             /* Create a new hub and chain it on */
             hub = usb_try_new("usb-hub");
             if (hub) {
                 usb_realize_and_unref(hub, bus, NULL);
             }
         }
+#endif 
         if (bus->nfree == 0) {
             error_setg(errp, "tried to attach usb device %s to a bus "
                        "with no free ports", dev->product_desc);


### PR DESCRIPTION
### Description

A recent change in the MINI FW (prusa3d/Prusa-Firmware-Buddy#1626) includes additional runtime configuration checks to ensure the priority configuration bits are set correctly. The default emulated value for the armv7m nvic controller is 8, which fails to pass these tests.

We override the default to 4 behind our new spiffy ``CONFIG_PRUSA_STM32_HACKS`` define until we discuss with upstream to have this as a priority that can be overridden directly in the target board.

### Behaviour/ Breaking changes

No behavior change for old MINI versions. Fixes the behavior on newer ones.

### Have you tested the changes?

Tested locally.

### Linked issues:

 - prusa3d/Prusa-Firmware-Buddy#1626
