### PR TITLE
Allow MK4 nozzle maxtemp

### DIFF
--- a/hw/arm/prusa/parts/thermistor.c
+++ b/hw/arm/prusa/parts/thermistor.c
@@ -175,7 +175,7 @@ static void thermistor_set_table(ThermistorState *s) {
             s->table = &temptable_2004[0][0];
 			break;
         case 2005:
-            s->table_length = 21*2;
+            s->table_length = 22*2;
             s->table = &temptable_2005[0][0];
             break;
         case 21:

--- a/hw/arm/prusa/parts/thermistortables.h
+++ b/hw/arm/prusa/parts/thermistortables.h
@@ -1350,6 +1350,7 @@ const short temptable_2004[][2] PROGMEM = {
 
 
 const short temptable_2005[][2] PROGMEM = {
+{ OVERSAMPLENR*(50), 350 }, // Synthetic value to test max temp error
 { OVERSAMPLENR*(78), 300 },
 { OVERSAMPLENR*(102), 280 },
 { OVERSAMPLENR*(134), 260 },


### PR DESCRIPTION
Extend thermistor table to enable maxtemp on nozzle. This enables maxtemp integration test support.

Idea: What about computing the temperature using a function rather than using a table?