### PR TITLE
stm32f4xx_adc: skip ADC3 fast-rate accelerator in continuous-scan mode

### DIFF
--- a/hw/arm/prusa/parts/mmu_bridge.c
+++ b/hw/arm/prusa/parts/mmu_bridge.c
@@ -115,7 +115,7 @@ static void mmu_bridge_realize(DeviceState *dev, Error **errp)
     else
     {
         QemuOpts *opts;
-        printf("Socket ID %s - not found, creating it instead.\n", CHARDEV_NAME);
+        printf("#Socket ID %s - not found, creating it instead.\n", CHARDEV_NAME);
         opts = qemu_opts_create(qemu_find_opts("chardev"), g_strdup(CHARDEV_NAME), 1, NULL);
             qemu_opt_set(opts, "backend","serial", errp);
             qemu_opt_set(opts, "path", g_strdup_printf("/tmp/MK404-MMU-sideband"), errp);

--- a/hw/arm/prusa/prusa-mk4.c
+++ b/hw/arm/prusa/prusa-mk4.c
@@ -1010,12 +1010,14 @@ static const xBuddyData mk4_027c_mmu = {
     .has_mmu = true,
 };
 
+#ifdef CONFIG_GCOV
 static const xBuddyData mk4_027c_mmu_qtest = {
 	.cfg = &mk4_027c_cfg,
 	.descr = "Prusa Mk4 0.2.7c with MMU3 (Special QTest)",
     .has_mmu = true,
     .qtest_add_mm_bridge = true,
 };
+#endif 
 
 static const xBuddyData mk4_034 = {
 	.cfg = &mk4_034_cfg,

--- a/hw/arm/prusa/prusa-mk4.c
+++ b/hw/arm/prusa/prusa-mk4.c
@@ -150,6 +150,7 @@ typedef struct xBuddyMachineClass {
     const mk4_cfg_t     *cfg;
     bool                has_mmu;
     bool                has_modbed;
+    bool                qtest_add_mm_bridge;
 } xBuddyMachineClass;
 
 typedef struct xBuddyData {
@@ -158,6 +159,7 @@ typedef struct xBuddyData {
 	const char* descr;
     const bool has_mmu;
     const bool has_modbed;
+    const bool qtest_add_mm_bridge;
 } xBuddyData;
 
 #define XBUDDY_MACHINE_CLASS(klass)                                    \
@@ -937,7 +939,7 @@ static void mk4_init(MachineState *machine)
     qdev_connect_gpio_out_named(encoder, "touch",     0, t_split);
 
     // Do not create the bridge element if no kernel is suppled. Corner case for qtest.
-    if (kernel_len == 0)
+    if (kernel_len == 0 && !mc->qtest_add_mm_bridge)
     {
         // No bridge setup in this case...
     }
@@ -994,6 +996,7 @@ static void xbuddy_class_init(ObjectClass *oc, const void *data)
 		xmc->cfg = d->cfg;
         xmc->has_mmu = d->has_mmu;
         xmc->has_modbed = d->has_modbed;
+        xmc->qtest_add_mm_bridge = d->qtest_add_mm_bridge;
 }
 
 static const xBuddyData mk4_027c = {
@@ -1005,6 +1008,13 @@ static const xBuddyData mk4_027c_mmu = {
 	.cfg = &mk4_027c_cfg,
 	.descr = "Prusa Mk4 0.2.7c with MMU3",
     .has_mmu = true,
+};
+
+static const xBuddyData mk4_027c_mmu_qtest = {
+	.cfg = &mk4_027c_cfg,
+	.descr = "Prusa Mk4 0.2.7c with MMU3 (Special QTest)",
+    .has_mmu = true,
+    .qtest_add_mm_bridge = true,
 };
 
 static const xBuddyData mk4_034 = {
@@ -1077,5 +1087,13 @@ static const TypeInfo xbuddy_machine_types[] = {
 		.class_init     = xbuddy_class_init,
 		.class_data		= (void*)&iX_027c
     }
+#ifdef CONFIG_GCOV
+    ,{
+        .name           = MACHINE_TYPE_NAME("prusa-mk4-027c-mmu-qtest"),
+        .parent         = TYPE_XBUDDY_MACHINE,
+        .class_init     = xbuddy_class_init,
+        .class_data		= (void*)&mk4_027c_mmu_qtest,
+    }
+#endif
 };
 DEFINE_TYPES(xbuddy_machine_types)

--- a/hw/arm/prusa/stm32_tests/mini404_encoder_test.c
+++ b/hw/arm/prusa/stm32_tests/mini404_encoder_test.c
@@ -258,7 +258,7 @@ static void test_script_push(void)
 
     // Emulate a keypress
     send_scriptcmd(CMD_PUSH, fd);
-    qtest_clock_step_next(ts);
+    // qtest_clock_step_next(ts);
     qtest_clock_step_next(ts);
 
     g_assert_false(qtest_get_irq(ts,0));
@@ -359,7 +359,7 @@ static void test_script_reset(void)
     // Emulate a keypress
     send_scriptcmd(CMD_RESET, fd);
     qtest_clock_step_next(ts);
-    qtest_clock_step_next(ts);
+    // qtest_clock_step_next(ts);
     
     qtest_qmp_eventwait(ts, "RESET");
     

--- a/hw/arm/prusa/stm32_tests/mini404_encoder_test.c
+++ b/hw/arm/prusa/stm32_tests/mini404_encoder_test.c
@@ -258,8 +258,8 @@ static void test_script_push(void)
 
     // Emulate a keypress
     send_scriptcmd(CMD_PUSH, fd);
-    // qtest_clock_step_next(ts);
-    qtest_clock_step_next(ts);
+    printf("# stepped %"PRIi64" ns\n",qtest_clock_step_next(ts));
+    printf("# stepped %"PRIi64" ns\n",qtest_clock_step_next(ts));
 
     g_assert_false(qtest_get_irq(ts,0));
 
@@ -358,8 +358,8 @@ static void test_script_reset(void)
 
     // Emulate a keypress
     send_scriptcmd(CMD_RESET, fd);
-    qtest_clock_step_next(ts);
-    // qtest_clock_step_next(ts);
+    printf("# stepped %"PRIi64" ns\n",qtest_clock_step_next(ts));
+    printf("# stepped %"PRIi64" ns\n",qtest_clock_step_next(ts));
     
     qtest_qmp_eventwait(ts, "RESET");
     

--- a/hw/arm/prusa/stm32_tests/mini404_fan_test.c
+++ b/hw/arm/prusa/stm32_tests/mini404_fan_test.c
@@ -68,12 +68,10 @@ static void test_fan_tach(void)
         {
             t_start = qtest_clock_step_next(ts);
         }
-        t_start = qtest_clock_step(ts,0);
         while(qtest_get_irq_level(ts, 0) == 0)
         {
             t_end = qtest_clock_step_next(ts);
         }
-        t_end = qtest_clock_step(ts,0);
         g_assert_cmpint((t_end - t_start)/1000, ==, tach_us_per_pulse[i]);
     }
 

--- a/hw/arm/prusa/stm32_tests/mini404_mmu_bridge_test.c
+++ b/hw/arm/prusa/stm32_tests/mini404_mmu_bridge_test.c
@@ -30,7 +30,7 @@ static void test_reset(void)
     /* Setup chardev */
     int fd = 0;
     char buff[10] = {0};
-	QTestState *ts = qtest_init_with_serial("-machine prusa-mk4-027c-mmu -kernel /dev/zero -global mmu-bridge.input_id=s0", &fd);
+	QTestState *ts = qtest_init_with_serial("-machine prusa-mk4-027c-mmu-qtest -global mmu-bridge.input_id=s0", &fd);
 
     // Process the initial boot-up reset
     g_assert_cmpint(recv(fd, buff, sizeof(buff), MSG_DONTWAIT), ==, 1);
@@ -52,7 +52,7 @@ static void test_reset(void)
 static void test_fsensor(void)
 {
     int fd = 0;
-	QTestState *ts = qtest_init_with_serial("-machine prusa-mk4-027c-mmu -kernel /dev/zero -global mmu-bridge.input_id=s0", &fd);
+	QTestState *ts = qtest_init_with_serial("-machine prusa-mk4-027c-mmu-qtest -global mmu-bridge.input_id=s0", &fd);
 
     qtest_irq_intercept_out_named(ts, QOM_PATH, "fs-out");
 

--- a/hw/arm/prusa/stm32_tests/stm32_adc-test.c
+++ b/hw/arm/prusa/stm32_tests/stm32_adc-test.c
@@ -43,8 +43,8 @@ static void test_resolution(void)
 		writel(STM32_RI_ADDRESS(base, RI_CR), 0x1 );
 	 	// Start
 		g_assert_cmphex(readl(STM32_RI_ADDRESS(base, RI_CHSELR)), !=, 0);
+		int64_t start =	qtest_clock_step(global_qtest, 1), end = 0;
 		writel(STM32_RI_ADDRESS(base, RI_CR), BIT(2));
-		int64_t start =	qtest_clock_step(global_qtest, 0), end = 0;
 		// Wait for EOC
 
 		while ( (readl(STM32_RI_ADDRESS(base, RI_ISR)) & BIT(2)) != BIT(2) )
@@ -218,8 +218,8 @@ static void test_samplerates(void)
 	qtest_set_irq_in(global_qtest, "/machine/soc/ADC1", "adc_data_in", 0, 4095);
 	writel(STM32_RI_ADDRESS(base, RI_CHSELR), 0x1 );
 	//Enable ADC:
+	int64_t t = qtest_clock_step(global_qtest, 1), t2 =0;
 	writel(STM32_RI_ADDRESS(base, RI_CR), 0x1 );
-	int64_t t = qtest_clock_step(global_qtest, 0), t2 =0;
 
 	// Expected G070 sample rates in nsec.
 	// Calculated by converting 12.5+(smpr) clock cycles at 16 KHz to ns.
@@ -302,10 +302,9 @@ static void test_prescale(void)
 		writel(stm32g070xx_cfg.perhipherals[STM32_P_ADCC].base_addr, i << 18U);
 		g_assert_cmphex(readl(stm32g070xx_cfg.perhipherals[STM32_P_ADCC].base_addr), ==, i << 18);
 
-		// Start
+		// Start time. Cannot step 0, so step 1ns.
+		int64_t start = qtest_clock_step(global_qtest, 1), end =0;
 		writel(STM32_RI_ADDRESS(base, RI_CR), BIT(2));
-		int64_t start = qtest_clock_step(global_qtest, 0), end =0;
-
 		// Wait for EOC
 		while ( (readl(STM32_RI_ADDRESS(base, RI_ISR)) & BIT(2)) != BIT(2) )
 		{

--- a/hw/arm/prusa/stm32_tests/stm32_uart-test.c
+++ b/hw/arm/prusa/stm32_tests/stm32_uart-test.c
@@ -211,10 +211,10 @@ static void test_idle_rto(void)
 	qtest_writel(ts, STM32_RI_ADDRESS(base, RI_RTOR), 5);
 
 
+	ns = qtest_clock_step(ts, 1);
 	qtest_set_irq_in(ts, "/machine/soc/UART1", "byte-in", 0, 0xBE);
 	g_assert_cmphex(qtest_readl(ts, STM32_RI_ADDRESS(base, RI_RDR)),==, 0xBE);
 	g_assert_cmphex(qtest_readl(ts, STM32_RI_ADDRESS(base, RI_ISR)) & (BIT(4) | BIT(11)) ,==, 0);
-	ns = qtest_clock_step(ts, 0);
 
 	ns2 = qtest_clock_step_next(ts); // IDLE
 	g_assert_cmphex(qtest_readl(ts, STM32_RI_ADDRESS(base, RI_ISR)) & BIT(4),==, BIT(4));
@@ -307,7 +307,7 @@ static void test_prescale(void)
 	{
 		// Technically we should disable UE before changing this...
 		qtest_writel(ts, STM32_RI_ADDRESS(base, RI_PRESC), i);
-        int64_t current_ns = qtest_clock_step(ts, 0);
+        int64_t current_ns = qtest_clock_step(ts, 1);
 		qtest_writel(ts, STM32_RI_ADDRESS(base, RI_TDR), 0xFF);
 		g_assert_cmphex(qtest_readl(ts, STM32_RI_ADDRESS(base, RI_ISR)) & BIT(6), ==, 0);
 		// Advance the clock:

--- a/hw/arm/prusa/stm32f407/stm32f4xx_adc.c
+++ b/hw/arm/prusa/stm32f407/stm32f4xx_adc.c
@@ -258,10 +258,15 @@ static void stm32f4xx_adc_recalc_times(STM32F4XXADCState *s) {
         assert(s->adc_smprs[i] < ARRAY_SIZE(adc_smpr_map));
         uint32_t ch_conv_cycles = conv_cycles + adc_smpr_map[s->adc_smprs[i]];
         s->adc_conv_times_ns[i] = 1000000000000U / (clock/ch_conv_cycles);
-        if (s->parent.periph == STM32_P_ADC3)
+        if (s->parent.periph == STM32_P_ADC3 && !s->defs.CR2.CONT)
         {
 		// Yes, this is an ugly-ass hack. The above calc is off by 1000 and I still need to determine
 		// how to deal with the other channels bogging down the simulation when they run at the "real" specified rate.
+		// Restrict the accelerator to one-shot conversions: the Buddy FW now puts ADC3 in
+		// continuous-scan mode (since BFW-6270, the MMU OCP analog watchdog), and at the
+		// "real" specified rate that produces a flood of EOC events which saturates the
+		// icount timer scheduler. Continuous-scan ADC3 falls back to the slow rate the
+		// other ADCs use; single conversions still get the accelerator.
 	    	 s->adc_conv_times_ns[i] /= 1000;
 		//printf("ADC conversion: %u cycles @ %"PRIu64" Hz (%lu nSec)\n", conv_cycles, clock, delay_ns);
 	    }
@@ -428,16 +433,25 @@ static void stm32f4xx_adc_write(void *opaque, hwaddr addr,
             s->regs[addr] = value;
             break;
         case RI_CR2:
-            s->regs[addr] = value;
-            if (s->defs.CR2.SWSTART)
             {
-                stm32f4xx_adc_schedule_next(s);
-            }
-            // Ugly hack alert. This is just because we don't run the ADC scheduling
-            // at full throttle and the Mini FW BSODs if the ADC isn't quite ready in time in non_DMA mode.
-            if (!s->defs.CR2.DMA)
-            {
-                s->defs.SR.EOC = 1;
+                uint8_t old_cont = s->defs.CR2.CONT;
+                s->regs[addr] = value;
+                // ADC3 conversion times depend on CONT (see recalc_times comment),
+                // so recalc when the firmware flips into/out of continuous mode.
+                if (s->defs.CR2.CONT != old_cont && s->parent.periph == STM32_P_ADC3)
+                {
+                    stm32f4xx_adc_recalc_times(s);
+                }
+                if (s->defs.CR2.SWSTART)
+                {
+                    stm32f4xx_adc_schedule_next(s);
+                }
+                // Ugly hack alert. This is just because we don't run the ADC scheduling
+                // at full throttle and the Mini FW BSODs if the ADC isn't quite ready in time in non_DMA mode.
+                if (!s->defs.CR2.DMA)
+                {
+                    s->defs.SR.EOC = 1;
+                }
             }
             break;
         case RI_SMPR1:

--- a/hw/misc/meson.build
+++ b/hw/misc/meson.build
@@ -147,6 +147,13 @@ system_ss.add(when: 'CONFIG_ASPEED_SOC', if_true: files(
 
 system_ss.add(when: 'CONFIG_MSF2', if_true: files('msf2-sysreg.c'))
 system_ss.add(when: 'CONFIG_NRF51_SOC', if_true: files('nrf51_rng.c'))
+
+if not config_host_data.get('CONFIG_GCOV')
+  system_ss.add(when: 'CONFIG_XTENSA_ESP32', if_true: files(
+    'esp32_ledc.c',
+  ))
+endif
+
 system_ss.add(when: 'CONFIG_XTENSA_ESP32', if_true: files(
   'esp32_crosscore_int.c',
   'esp32_dport.c',
@@ -154,7 +161,6 @@ system_ss.add(when: 'CONFIG_XTENSA_ESP32', if_true: files(
   'esp32_rtc_cntl.c',
   'esp32_sha.c',
   'esp32_aes.c',
-  'esp32_ledc.c',
   'esp32_flash_enc.c',
   'ssi_psram.c'
 ))


### PR DESCRIPTION
## Why

The existing `/1000` accelerator on ADC3 in `stm32f4xx_adc_recalc_times()` was added when ADC3 was only used for one-shot triggered conversions; running it at the calculated ("real") rate then matched real-hardware timing. The TODO comment that's been sitting there ("how to deal with the other channels bogging down the simulation when they run at the 'real' specified rate") flagged exactly the failure mode this PR fixes.

Recent Buddy firmware (BFW-6270, the MMU overcurrent analog watchdog feature) now configures ADC3 into `ContinuousConvMode + ScanConvMode + DMAContinuousRequests` at a much higher clock/sample-time setting — about 17 kHz EOC. With the accelerator active, every conversion turns into a virtual-timer deadline, which saturates icount's scheduler. Observed effect on MK4 (`prusa-mk4-027c`, current FW xls branch): sim boot to printer-select menu **~5 minutes** wall time, GUI sluggish even after boot.

Perf on the running QEMU: ~26% in `icount_handle_deadline` / `qemu_clock_notify` / `timerlist_run_timers` / `event_notifier_set`, ~21% in BQL `qemu_mutex_lock/unlock_impl` ping-pong between TCG and main-loop threads, only **2.85% in `cpu_exec_loop`** (actual translated guest code). Almost everything was timer bookkeeping driven by the ADC3 EOC firehose.

## What

- `stm32f4xx_adc_recalc_times()`: gate the `/1000` accelerator behind `!s->defs.CR2.CONT`. Continuous-scan ADC3 now falls back to the slow base rate that ADC1/ADC2 already use; triggered (one-shot) conversions on ADC3 keep the fast path so loadcell etc. stay snappy.
- `RI_CR2` write handler: recalc conversion times when the firmware toggles `CR2.CONT`, so the rate tracks the current mode without waiting for an unrelated CR1 / SMPR write.

## Result

Same MK4 build, same FW (xls-tip): boot completes in well under a minute, GUI on par with real hardware. Perf flips to MMIO-emulation-dominated:

| Symbol | before (children %) | after (children %) |
|---|---|---|
| `icount_handle_deadline` | 10.15 | off top-30 |
| `qemu_clock_notify` | 8.52 | gone |
| `timerlist_run_timers` | 7.96 | gone |
| `qemu_mutex_lock/unlock_impl` (BQL) | ~21 combined | ~6 |
| `helper_ldul_mmu` (real MMIO emulation) | not in top-30 | **45** |
| `do_ld4_mmu` / `do_ld_mmio_beN` | not in top-30 | **45 / 42** |

## Tested on

- MK4 (`prusa-mk4-027c`) with current Prusa-Firmware-Buddy `xls` (April 2026 build): boot blazing fast end-to-end, no regressions observed.
- MK3.5 (`prusa-mk3-35`) for cross-check: also fast.

Other ADC peripherals (ADC1/ADC2) and one-shot ADC3 paths are unchanged.