### PR TITLE
stm32f4xx_adc: skip ADC3 fast-rate accelerator in continuous-scan mode

### DIFF
--- a/hw/arm/prusa/stm32f407/stm32f4xx_adc.c
+++ b/hw/arm/prusa/stm32f407/stm32f4xx_adc.c
@@ -258,10 +258,15 @@ static void stm32f4xx_adc_recalc_times(STM32F4XXADCState *s) {
         assert(s->adc_smprs[i] < ARRAY_SIZE(adc_smpr_map));
         uint32_t ch_conv_cycles = conv_cycles + adc_smpr_map[s->adc_smprs[i]];
         s->adc_conv_times_ns[i] = 1000000000000U / (clock/ch_conv_cycles);
-        if (s->parent.periph == STM32_P_ADC3)
+        if (s->parent.periph == STM32_P_ADC3 && !s->defs.CR2.CONT)
         {
 		// Yes, this is an ugly-ass hack. The above calc is off by 1000 and I still need to determine
 		// how to deal with the other channels bogging down the simulation when they run at the "real" specified rate.
+		// Restrict the accelerator to one-shot conversions: the Buddy FW now puts ADC3 in
+		// continuous-scan mode (since BFW-6270, the MMU OCP analog watchdog), and at the
+		// "real" specified rate that produces a flood of EOC events which saturates the
+		// icount timer scheduler. Continuous-scan ADC3 falls back to the slow rate the
+		// other ADCs use; single conversions still get the accelerator.
 	    	 s->adc_conv_times_ns[i] /= 1000;
 		//printf("ADC conversion: %u cycles @ %"PRIu64" Hz (%lu nSec)\n", conv_cycles, clock, delay_ns);
 	    }
@@ -428,16 +433,25 @@ static void stm32f4xx_adc_write(void *opaque, hwaddr addr,
             s->regs[addr] = value;
             break;
         case RI_CR2:
-            s->regs[addr] = value;
-            if (s->defs.CR2.SWSTART)
             {
-                stm32f4xx_adc_schedule_next(s);
-            }
-            // Ugly hack alert. This is just because we don't run the ADC scheduling
-            // at full throttle and the Mini FW BSODs if the ADC isn't quite ready in time in non_DMA mode.
-            if (!s->defs.CR2.DMA)
-            {
-                s->defs.SR.EOC = 1;
+                uint8_t old_cont = s->defs.CR2.CONT;
+                s->regs[addr] = value;
+                // ADC3 conversion times depend on CONT (see recalc_times comment),
+                // so recalc when the firmware flips into/out of continuous mode.
+                if (s->defs.CR2.CONT != old_cont && s->parent.periph == STM32_P_ADC3)
+                {
+                    stm32f4xx_adc_recalc_times(s);
+                }
+                if (s->defs.CR2.SWSTART)
+                {
+                    stm32f4xx_adc_schedule_next(s);
+                }
+                // Ugly hack alert. This is just because we don't run the ADC scheduling
+                // at full throttle and the Mini FW BSODs if the ADC isn't quite ready in time in non_DMA mode.
+                if (!s->defs.CR2.DMA)
+                {
+                    s->defs.SR.EOC = 1;
+                }
             }
             break;
         case RI_SMPR1:


### PR DESCRIPTION
This is a cherry pick of the commit form #179 onto the merged main branch post-v11 by @DRracer 

WIP, may need some refinement/cleanup