### PR TITLE
loadcell: parameterized loadcell::Tap(force_grams, duration_ms) action

### DIFF
--- a/hw/arm/prusa/parts/loadcell.c
+++ b/hw/arm/prusa/parts/loadcell.c
@@ -51,6 +51,33 @@ struct LoadcellState {
 	uint8_t tap;
 	p404_key_handle key;
 	QEMUTimer* timer;
+
+	/* Parameterized tap (loadcell::Tap script action). Independent state so the
+	 * legacy KeyCtl::Key('t') path keeps working unchanged. */
+	int32_t ptap_peak_raw;
+	int32_t ptap_total_ticks;
+	int32_t ptap_current_tick;
+	uint8_t ptap_state;          /* 0 = idle, 1 = running, 2 = just-finished (awaiting acknowledge) */
+	QEMUTimer* ptap_timer;
+};
+
+/* Sim-emit raw value → FW grams chain (MK4):
+ *   1) loadcell qemu_set_irq(value)      (this file, "input_x1000" output)
+ *   2) hx717 input_x1000:  value_gain = value * 128 / 1000   (parts/hx717.c)
+ *   3) FW Loadcell::load = (loadcellRaw - tare_offset) * scale,
+ *      with scale = 0.0192 g/count  (Buddy/src/common/loadcell.hpp)
+ *   4) selftest_loadcell.cpp: load = -1 * Loadcell::load()   (positive = up)
+ *
+ * So: FW_grams ≈ -value * 128/1000 * 0.0192  ≈  -value / 407
+ * Inverting for `loadcell::Tap(force_grams, ...)`:
+ *   peak_raw = -force_grams * 407   (negative because positive force = up = -ve raw)
+ *
+ * Current FW selftest expects load in [500, 2000] g (selftest_MK4.cpp tap_*),
+ * so force_grams = 1000 lands mid-range. */
+#define LOADCELL_GRAMS_TO_RAW 407
+
+enum {
+    ActTap = 1,
 };
 
 #define PIN_POSITION_X (180 + 8)
@@ -192,15 +219,71 @@ static void loadcell_input_handle_key(P404KeyIF *opaque, Key keycode)
 	}
 }
 
+static void loadcell_param_tap_timer(void *opaque)
+{
+    LoadcellState *s = LOADCELL(opaque);
+    int32_t total = s->ptap_total_ticks;
+    int32_t t = s->ptap_current_tick;
+
+    if (total < 2 || t > total) {
+        /* Pulse complete — drop force back to idle and signal the script-side action. */
+        qemu_set_irq(s->irq, 10);
+        s->ptap_state = 2;
+        return;
+    }
+
+    int32_t half = total / 2;
+    int32_t value;
+    if (half <= 0) {
+        value = s->ptap_peak_raw;
+    } else if (t <= half) {
+        value = (int32_t)(((int64_t)s->ptap_peak_raw * t) / half);
+    } else {
+        int32_t down = total - t;
+        if (down < 0) down = 0;
+        value = (int32_t)(((int64_t)s->ptap_peak_raw * down) / half);
+    }
+
+    qemu_set_irq(s->irq, value);
+    s->ptap_current_tick = t + 1;
+    timer_mod(s->ptap_timer, qemu_clock_get_ms(QEMU_CLOCK_VIRTUAL) + 10);
+}
+
 static int loadcell_process_action(P404ScriptIF *obj, unsigned int action, script_args args)
 {
-    // LoadcellState *s = LOADCELL(obj);
+    LoadcellState *s = LOADCELL(obj);
     switch (action)
     {
+        case ActTap:
+            switch (s->ptap_state) {
+                case 1: /* running */
+                    return ScriptLS_Waiting;
+                case 2: /* just finished */
+                    s->ptap_state = 0;
+                    s->ptap_total_ticks = 0;
+                    s->ptap_current_tick = 0;
+                    return ScriptLS_Finished;
+                case 0:
+                default: {
+                    int force_grams = scripthost_get_int(args, 0);
+                    int duration_ms = scripthost_get_int(args, 1);
+                    if (duration_ms < 20) {
+                        duration_ms = 20;
+                    }
+                    /* FW polarity: positive force_grams = "tap pushing nozzle up" => negative raw. */
+                    s->ptap_peak_raw = -force_grams * LOADCELL_GRAMS_TO_RAW;
+                    s->ptap_total_ticks = duration_ms / 10;
+                    s->ptap_current_tick = 1;
+                    s->ptap_state = 1;
+                    printf("Loadcell parameterized tap: %d g over %d ms (peak raw %d)\n",
+                           force_grams, duration_ms, s->ptap_peak_raw);
+                    timer_mod(s->ptap_timer, qemu_clock_get_ms(QEMU_CLOCK_VIRTUAL) + 10);
+                    return ScriptLS_Waiting;
+                }
+            }
         default:
             return ScriptLS_Unhandled;
     }
-    return ScriptLS_Finished;
 }
 
 static void loadcell_init(Object *obj)
@@ -211,12 +294,22 @@ static void loadcell_init(Object *obj)
     qdev_init_gpio_in_named(DEVICE(obj), loadcell_cal_pin_in,"cal-pin-state", 1);
 
     script_handle pScript = script_instance_new(P404_SCRIPTABLE(obj), TYPE_LOADCELL);
+    script_register_action(pScript, "Tap",
+        "Apply a force pulse of <peak_grams> over <duration_ms> (triangular ramp), synchronously.",
+        ActTap);
+    script_add_arg_int(pScript, ActTap);
+    script_add_arg_int(pScript, ActTap);
     scripthost_register_scriptable(pScript);
 
 	s->key = p404_new_keyhandler(P404_KEYCLIENT(obj));
     p404_register_keyhandler(s->key, 't',"Taps the loadcell");
 
 	s->timer = timer_new_ms(QEMU_CLOCK_VIRTUAL, loadcell_tap_timer, s);
+	s->ptap_timer = timer_new_ms(QEMU_CLOCK_VIRTUAL, loadcell_param_tap_timer, s);
+	s->ptap_state = 0;
+	s->ptap_total_ticks = 0;
+	s->ptap_current_tick = 0;
+	s->ptap_peak_raw = 0;
 }
 
 static const VMStateDescription vmstate_loadcell = {


### PR DESCRIPTION
## Summary

Adds a new synchronous script action on the `loadcell` device:

```
loadcell::Tap(int force_grams, int duration_ms)
```

It produces a triangular ramp `0 → peak → 0` over `duration_ms` (10 ms tick) and returns `FINISHED` only after the last tick. State is kept separate from the legacy `KeyCtl::Key('t')` path, so existing scripts keep working unchanged.

## Why

The current Buddy MK4 selftest expects loadcell load in `[500, 2000] g` and treats `|load| ≥ 250 g` during the 5 s countdown as "touched too early". A host-driven test rig has no way to dial the existing fixed-shape pulse — and crucially, no way to time it deterministically inside the 2 s NOW window after the countdown — so the existing tap key cannot reliably pass the selftest in CI / agent-driven scenarios. A parameterized action with `ScriptLS_Waiting`/`Finished` semantics makes the timing deterministic.

## Calibration

```
peak_raw = -force_grams * LOADCELL_GRAMS_TO_RAW    (407)
```

`407 ≈ 1 / (128/1000 * 0.0192)` — derived from the HX717 model's `value * 128 / 1000` chain (`hx717.c`) and Buddy FW `Loadcell::scale = 0.0192 g/count`. With `Tap(1000, 500)`, the FW reads load ~ `+1000 g`, comfortably inside `[500, 2000]`. Full chain is documented in the source comment block.

## Verification

- Built and ran on `prusa-mk4-027c`. `loadcell::Tap` shows up in `scripthelpmd`.
- Walked the MK4 first-boot wizard via the scripting console; `Tap(1000, 500)` fired ~0.7 s into the NOW window produces the "Test tensometru OK" screen and the snake advances to Z calibration.
- The legacy `KeyCtl::Key('t')` path is left untouched and still works.

## Scope

- `hw/arm/prusa/parts/loadcell.c` only — ~95 added LOC, 2 lines changed.
- No public-API changes elsewhere; no behaviour change for existing users.

## Test plan

- [ ] `scripthelpmd` lists `loadcell::Tap(int, int)` with description.
- [ ] Boot MK4 firmware (≥6.6.0) on `prusa-mk4-027c`, walk to loadcell selftest, send `loadcell::Tap(1000,500)` ~0.7 s into NOW window, observe "Test tensometru OK".
- [ ] Confirm `KeyCtl::Key(t)` still fires the legacy fixed-shape pulse.