### PR TITLE
stm32f4xx_usb: fix CDC SET_LINE_CODING handshake so FW line_coding_cb sees requested baud

### DIFF
--- a/hw/arm/prusa/stm32f407/stm32f4xx_usb.c
+++ b/hw/arm/prusa/stm32f407/stm32f4xx_usb.c
@@ -674,6 +674,10 @@ struct STM32F4xxUSBState {
 
     char cdc_in;
 
+    /* Initial dwDTERate sent in SET_LINE_CODING. Buddy FW gates syslog routing on
+       57600 (default) and Marlin console on 115200; FW may then re-set it later. */
+    uint32_t cdc_baud;
+
     CharFrontend cdc;
 
 };
@@ -700,10 +704,14 @@ static const uint32_t DEV_GETDESC[] = {0x000C0040, 0x03020680, 0x00FF0000};
 static const uint32_t DEV_GETDESC2[] = {0x000C0040, 0x03010680, 0x00FF0000};
 static const uint32_t DEV_GETDESC3[] = {0x000C0040, 0x03030680, 0x00FF0000};
 static const uint32_t DEV_SETCONF[] = {0x000C0040, 0x00010900, 0x00000000};
-// ALERT: this is a bit of a bastardization of the protocol where we cheat to "skip ahead" to the ACK stage and avoid a third cycle.
-// This really should be 0x2021 in the second ui32 followed by a "status" packet at the very end...
-static const uint32_t DEV_SETCODING[] = {0x000C0040, 0x000020A1, 0x00070000};
-static const uint32_t DEV_SETCODING2[] = {0x00040070, 0x00002580, 0x00080000};
+// SET_LINE_CODING SETUP packet: bmRequestType=0x21 (H->D, class, interface), bRequest=0x20, wLength=7.
+// Packet header: PKTSTS=SETUP(6), BCNT=4 (FW reads 8 bytes regardless).
+static const uint32_t DEV_SETCODING[] = {0x000C0040, 0x00002021, 0x00070000};
+// OUT data stage: 7 bytes of line coding (dwDTERate[4], bCharFormat[1], bParityType[1], bDataBits[1]).
+// dwDTERate is patched at runtime from the cdc_baud device property; bDataBits=8 in the high byte of the third word.
+// Packet header: PKTSTS=OUT(2), BCNT=7.
+#define DEV_SETCODING2_HEADER 0x00040070u
+#define DEV_SETCODING2_TAIL   0x00080000u   /* bCharFormat=0 (1 stop), bParityType=0 (none), bDataBits=8 */
 static const uint32_t DEV_SETCTLLINE[] = {0x000C0040, 0x00032221, 0x00000000};
 static const uint32_t DEV_OUT_HEADER = 0x40012;
 static const uint32_t DEV_OUT_AT[] = {0x00040022, 0x00000a0d};
@@ -750,6 +758,7 @@ enum {
      DEVSTATE(SETCFG)
      DEVSTATE(LINECODING)
     //  DEVSTATE(LINECODING_DATA)
+     DEV_ST_LINECODING_STATUS_WAIT,
      DEVSTATE(SETCTLLINE)
      DEV_ST_IO_READY,
      DEVSTATE(USBIP)
@@ -1146,10 +1155,45 @@ static void f4xx_usb_cdc_setup(STM32F4xxUSBState *s)
 			s->device_state++;
 			break;
 		case DEV_ST_LINECODING_WAIT:
-			f4xx_usb_cdc_sendpkt(s, DEV_SETCODING2, sizeof(DEV_SETCODING2)/sizeof(uint32_t));
+		{
+			/* FW armed EP0 OUT for the data stage of SET_LINE_CODING. Push the 7
+			   bytes of line coding (dwDTERate, bCharFormat, bParityType, bDataBits)
+			   into the RX FIFO. dwDTERate comes from the cdc_baud property. */
+			uint32_t pkt[3];
+			pkt[0] = DEV_SETCODING2_HEADER;
+			pkt[1] = s->cdc_baud;            /* dwDTERate (bytes 0-3) */
+			pkt[2] = DEV_SETCODING2_TAIL;    /* byte 4=charfmt, 5=parity, 6=databits=8 */
+			f4xx_usb_cdc_sendpkt(s, pkt, ARRAY_SIZE(pkt));
+			/* Real OTG decrements DOEPTSIZ.XFRSIZ by the bytes received. TinyUSB
+			   computes xferred_bytes = total_len - DOEPTSIZ.XFRSIZ on a short packet
+			   (dcd_dwc2.c handle_rxflvl_irq OUTRX path); if we don't update XFRSIZ,
+			   FW sees xferred=0, the memcpy into &p_cdc->line_coding copies nothing,
+			   bit_rate stays at TinyUSB's 115200 default and line_coding_cb fires
+			   switch_to_marlin instead of switch_to_logging. */
+			if (s->drego[0].DIEPTSIZ.XFRSIZ >= 7) {
+				s->drego[0].DIEPTSIZ.XFRSIZ -= 7;
+			} else {
+				s->drego[0].DIEPTSIZ.XFRSIZ = 0;
+			}
             STM32F4xx_raise_device_ep_out_irq(s, 0, DOEPMSK_XFERCOMPLMSK);
-            timer_mod(s->cdc_timer, qemu_clock_get_us(QEMU_CLOCK_VIRTUAL) + 100);
-			s->device_state++;
+            /* Don't auto-advance — wait for FW to arm EP0 IN for the status ZLP.
+               That EPENA write triggers cdc_schedule via STM32F4xx_dregin_write. */
+			s->device_state++;   /* -> DEV_ST_LINECODING_STATUS_WAIT */
+			break;
+		}
+		case DEV_ST_LINECODING_STATUS_WAIT:
+			/* FW armed DIEP0 EPENA with PKTCNT=1, XFRSIZ=0 to send the status-IN
+			   ZLP that ACKs SET_LINE_CODING. Consume it and advance. */
+			s->fifo_head[0] = s->fifo_tail[0] = s->fifo_level[0] = 0;
+			s->dregi[0].DIEPTSIZ.XFRSIZ = 0;
+			if (s->dregi[0].DIEPTSIZ.PKTCNT > 0) {
+				s->dregi[0].DIEPTSIZ.PKTCNT--;
+			}
+			s->dregi[0].DIEPCTL.EPENA = 0;
+			STM32F4xx_raise_device_ep_in_irq(s, 0, DIEPMSK_XFERCOMPLMSK);
+			STM32F4xx_update_device_common_irq(s);
+			s->device_state = DEV_ST_SETCTLLINE;
+			STM32F4xx_cdc_schedule(s);
 			break;
 		case DEV_ST_SETCTLLINE:
             f4xx_usb_cdc_sendpkt(s, DEV_SETCTLLINE, sizeof(DEV_SETCTLLINE)/sizeof(uint32_t));
@@ -1158,8 +1202,16 @@ static void f4xx_usb_cdc_setup(STM32F4xxUSBState *s)
             s->device_state++;
             break;
 		case DEV_ST_SETCTLLINE_WAIT:
+			/* FW armed DIEP0 EPENA for the status-IN ZLP of SET_CONTROL_LINE_STATE.
+			   Raise XFRC on EP0 IN so TinyUSB reaches CONTROL_STAGE_ACK and stores
+			   p_cdc->line_state (which is what tud_cdc_connected() checks for DTR). */
 			s->fifo_head[0] = s->fifo_tail[0] = s->fifo_level[0] = 0;
 			s->dregi[0].DIEPTSIZ.XFRSIZ = 0;
+			if (s->dregi[0].DIEPTSIZ.PKTCNT > 0) {
+				s->dregi[0].DIEPTSIZ.PKTCNT--;
+			}
+			s->dregi[0].DIEPCTL.EPENA = 0;
+			STM32F4xx_raise_device_ep_in_irq(s, 0, DIEPMSK_XFERCOMPLMSK);
 			STM32F4xx_update_device_common_irq(s);
 			printf("Control line set\n");
 			s->device_state = DEV_ST_IO_READY;
@@ -3315,6 +3367,7 @@ static const Property STM32F4xx_usb_properties[] = {
     DEFINE_PROP_CHR("chardev", STM32F4xxUSBState, cdc),
 	DEFINE_PROP_LINK("system-memory", STM32F4xxUSBState, cpu_mr, TYPE_MEMORY_REGION, MemoryRegion*),
     DEFINE_PROP_BOOL("disable_sof_interrupt", STM32F4xxUSBState, disable_sofi, false),
+    DEFINE_PROP_UINT32("cdc_baud", STM32F4xxUSBState, cdc_baud, 57600),
 };
 
 static void STM32F4xx_class_init(ObjectClass *klass, const void *data)


### PR DESCRIPTION
## Summary

Fixes the fake-host CDC enumeration in `f4xx_usb_cdc_setup` so a `SET_LINE_CODING` actually delivers the requested baud to the firmware's `tud_cdc_line_coding_cb`. Buddy FW uses this hook to route its USB-CDC stream — 57600 = syslog, 115200 = Marlin console — and on current QEMU 11 the previous handshake silently fed it 115200 every time, so the sim's `cdc.log` filled with raw Marlin `echo:` output and not a single syslog event.

The previous code carried a comment acknowledging it was a hack:
```
// ALERT: this is a bit of a bastardization of the protocol where we cheat to "skip ahead" to the ACK stage and avoid a third cycle.
// This really should be 0x2021 in the second ui32 followed by a "status" packet at the very end...
```
This PR is that "really should". Four-part patch:

1. **`DEV_SETCODING[1]`: `0x000020A1` → `0x00002021`** — `bmRequestType=0x21` (H→D, class, interface) is what the CDC spec requires for SET_LINE_CODING. The old `0xA1` was D→H, so TinyUSB's `usbd_control_xfer_cb` went down the IN path and never `memcpy`'d the OUT data into `p_cdc->line_coding`.

2. **New `DEV_ST_LINECODING_STATUS_WAIT` state** between `LINECODING_WAIT` and `SETCTLLINE`. After the OUT data is delivered, wait for FW to arm DIEP0 (status-IN ZLP) rather than timer-advancing. The existing DIEPCTL.EPENA write trigger fires `cdc_schedule`, so the wait is event-driven.

3. **Decrement `DOEPTSIZ.XFRSIZ` in `LINECODING_WAIT`** after pushing the 7-byte payload. This is the load-bearing fix. Real OTG silicon decrements XFRSIZ as bytes are received; TinyUSB's RXFLVL OUTRX path computes `xfer->total_len -= DOEPTSIZ.XFRSIZ` on a short-packet end-of-transfer (`dcd_dwc2.c handle_rxflvl_irq`). With XFRSIZ stuck at 7, FW saw `xferred_bytes=0`, the memcpy into `&p_cdc->line_coding` copied nothing, `bit_rate` stayed at TinyUSB's hard-coded 115200 default, and `tud_cdc_line_coding_cb` consequently fired `usb_cdc_switch_to_marlin`. Without this fix the proper `bmRequestType=0x21` path can't actually deliver the baud.

4. **`SETCTLLINE_WAIT` now raises XFRC on EP0 IN** (and clears EPENA / decrements PKTCNT, matching the new `LINECODING_STATUS_WAIT` pattern). Without the IN XFRC, TinyUSB never reached `CONTROL_STAGE_ACK` for SET_CONTROL_LINE_STATE, so `p_cdc->line_state` (DTR bit) stayed unset and `tud_cdc_connected()` kept returning false → `log_dest_usb` dropped every event. Invisible while bit_rate stayed at 115200 (the cb was flipping to Marlin anyway), but fatal the moment the SET_LINE_CODING fix lands.

Also adds a `cdc_baud` device property (default 57600 for syslog). Pass `-global STM32F4xx-usb.cdc_baud=115200` to enumerate as a 115200-baud Marlin console instead.

## Test plan

- [x] Build clean on QEMU 11 toolchain.
- [x] Boot prusa-mk4-027c with Buddy FW; confirm `cdc.log` fills with `Xs [INFO  - Component:N] message` syslog format from Buddy / Marlin / USBHost / MarlinServer (previously: zero syslog, only raw `echo:` Marlin lines).
- [ ] Sanity-check Marlin-console mode by running with `-global STM32F4xx-usb.cdc_baud=115200`.
- [ ] Smoke-test other Buddy targets (XL, Mini) that use the same f4xx_usb path.