### PR TITLE
heater: add SetSock action to bias thermal coefficient for nozzle-sock variants

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,12 +159,12 @@ jobs:
           msystem: MINGW64
           install: make git zip wget mingw-w64-x86_64-diffutils diffutils mingw-w64-x86_64-ninja mingw-w64-x86_64-toolchain mingw-w64-x86_64-gtk3 mingw-w64-x86_64-freeglut mingw-w64-x86_64-glew mingw-w64-x86_64-libusb mingw-w64-x86_64-SDL2  mingw-w64-x86_64-pixman  mingw-w64-x86_64-glib2 python-setuptools mingw-w64-x86_64-make mingw-w64-x86_64-curl mingw-w64-x86_64-libjxl mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-pcre
       
-      - name: Install old Python
-        run: |
-          wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-python-3.11.9-1-any.pkg.tar.zst
-          wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-python-3.11.9-1-any.pkg.tar.zst.sig
-          pacman --noconfirm -U mingw-w64-x86_64-python-3.11.9-1-any.pkg.tar.zst
-        shell: msys2 {0}
+      # - name: Install old Python
+      #   run: |
+      #     wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-python-3.11.9-1-any.pkg.tar.zst
+      #     wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-python-3.11.9-1-any.pkg.tar.zst.sig
+      #     pacman --noconfirm -U mingw-w64-x86_64-python-3.11.9-1-any.pkg.tar.zst
+      #   shell: msys2 {0}
         
       - name: Fix CRLF Checkout
         run: git config --global core.autocrlf false

--- a/hw/arm/prusa/parts/heater.c
+++ b/hw/arm/prusa/parts/heater.c
@@ -64,6 +64,7 @@ struct heater_state {
     uint64_t last_tick, last_off, last_on;
 
     bool is_ticking, use_custom_pwm;
+    bool sock_on;
 
     qemu_irq temp_out, pwm_out;
     QEMUTimer *temp_tick, *softpwm_timeout;
@@ -77,6 +78,14 @@ enum {
     ActOpen,
     ActSet,
 };
+
+/* Reduction factor applied to thermal_mass_x10 when the silicone heatblock
+   sock is fitted. Real with-sock heatup is slower because the sock adds
+   thermal mass to the assembly. The MK4 FW compensates with a -20 °C offset
+   on the heater selftest range (hotend_type.cpp::hotend_type_heater_selftest_offset
+   on HAS_NEXTRUDER); 0.85 lands the 42 s nozzle test reading inside that
+   shifted range. */
+#define HEATER_SOCK_MASS_FACTOR 0.85f
 extern float heater_calculate_current(heater_state *s);
 
 // Calculate current consumption based on given voltage/resistance, and scale by PWM.
@@ -178,11 +187,17 @@ static void heater_soft_pwm_change(void* opaque, int n, int level)
     }
 }
 
+static void heater_apply_sock(heater_state *s)
+{
+    float base = ((float)s->mass10x) / 10.f;
+    s->thermalMass = s->sock_on ? base * HEATER_SOCK_MASS_FACTOR : base;
+}
+
 static void heater_reset(DeviceState *dev)
 {
     heater_state *s = HEATER(dev);
 
-    s->thermalMass = ((float)s->mass10x)/10.f;
+    heater_apply_sock(s);
     s->ambientTemp = 18.f;
     s->currentTemp = s->ambientTemp;
     qemu_set_irq(s->temp_out, s->currentTemp*256.f);
@@ -256,6 +271,7 @@ static const Property heater_properties[] = {
     DEFINE_PROP_UINT8("label",heater_state, chrLabel, (uint8_t)' '),
 	DEFINE_PROP_UINT16("voltage_x100", heater_state, voltagex100, 2400),
 	DEFINE_PROP_UINT16("resistance_x100", heater_state, resistancex100, 0),
+	DEFINE_PROP_BOOL("has_sock", heater_state, sock_on, false),
 };
 
 static int heater_pre_save(void *opaque) {
@@ -269,7 +285,7 @@ static int heater_post_load(void *opaque, int version) {
     heater_state *s = HEATER(opaque);
     s->ambientTemp = (float)s->ambient_x100/100.f;
     s->currentTemp = (float)s->current_x100/100.f;
-    s->thermalMass = ((float)s->mass10x)/10.f;
+    heater_apply_sock(s);
     return 0;
 }
 
@@ -301,10 +317,17 @@ static const VMStateDescription vmstate_heater = {
 };
 
 
+static void heater_realize(DeviceState *dev, Error **errp)
+{
+    heater_state *s = HEATER(dev);
+    heater_apply_sock(s);
+}
+
 static void heater_class_init(ObjectClass *klass, const void *data)
 {
     DeviceClass *dc = DEVICE_CLASS(klass);
     device_class_set_legacy_reset(dc, heater_reset);
+    dc->realize = heater_realize;
     dc->vmsd = &vmstate_heater;
     device_class_set_props(dc, heater_properties);
 

--- a/hw/arm/prusa/prusa-mini.c
+++ b/hw/arm/prusa/prusa-mini.c
@@ -41,6 +41,9 @@
 #include "hw/arm/armv7m.h"
 #include "qobject/qlist.h"
 
+
+#define TYPE_BUDDY_MACHINE "buddy-machine"
+
 #define BOOTLOADER_IMAGE "bootloader.bin"
 
 #define XFLASH_FN  "Prusa_Mini_xflash.bin"
@@ -52,6 +55,11 @@ typedef struct mini_config_t {
     const char* flash_fn;
     int flash_size;
 } mini_config_t;
+
+typedef struct buddyData {
+    const char* descr;
+    const mini_config_t* cfg;
+} buddyData;
 
 static const mini_config_t mini_100_cfg = {
     .flash_chip = "w25q64jv",
@@ -65,23 +73,37 @@ static const mini_config_t mini_014_cfg = {
     .flash_size = 1U*MiB
 };
 
-static void prusa_mini_init(MachineState *machine, const mini_config_t* cfg);
+OBJECT_DECLARE_TYPE(buddyMachineState, buddyMachineClass, BUDDY_MACHINE);
 
-static void prusa_mini_014_init(MachineState *machine)
+typedef struct buddyMachineClass {
+    MachineClass parent_class;
+    const mini_config_t* cfg;
+} buddyMachineClass;
+
+typedef struct buddyMachineState {
+    MachineState parent;
+    bool has_sock;
+} buddyMachineState;
+
+static bool buddy_get_has_sock(Object *obj, Error **errp)
 {
-    prusa_mini_init(machine, &mini_014_cfg);
+    buddyMachineState *s = BUDDY_MACHINE(obj);
+    return s->has_sock;
 }
 
-static void prusa_mini_100_init(MachineState *machine)
+static void buddy_set_has_sock(Object *obj, bool value, Error **errp)
 {
-    prusa_mini_init(machine, &mini_100_cfg);
+    buddyMachineState *s = BUDDY_MACHINE(obj);
+    s->has_sock = value;
 }
 
-
-static void prusa_mini_init(MachineState *machine, const mini_config_t* cfg)
+static void prusa_mini_init(MachineState *machine)
 {
     DeviceState *dev;
     Object* periphs = machine_get_container("peripheral");
+    const buddyMachineState *s = BUDDY_MACHINE(machine);
+    const buddyMachineClass *mc = BUDDY_MACHINE_GET_CLASS(OBJECT(machine));
+    const mini_config_t* cfg = mc->cfg;
 
     dev = qdev_new(TYPE_STM32F407xG_SOC);
 	object_property_add_child(OBJECT(machine), "soc", OBJECT(dev));
@@ -312,6 +334,7 @@ static void prusa_mini_init(MachineState *machine, const mini_config_t* cfg)
     object_property_add_child(OBJECT(periphs), "heater-E", OBJECT(dev));
     qdev_prop_set_uint8(dev, "thermal_mass_x10",30);
     qdev_prop_set_uint8(dev,"label", 'E');
+    qdev_prop_set_bit(dev, "has_sock", s->has_sock);
     sysbus_realize(SYS_BUS_DEVICE(dev), &error_fatal);
     qdev_connect_gpio_out_named(stm32_soc_get_periph(dev_soc, STM32_P_TIM3),"pwm_ratio_changed",3,qdev_get_gpio_in_named(dev, "pwm_in",0));
     qdev_connect_gpio_out_named(dev, "temp_out",0, qdev_get_gpio_in_named(hotend, "thermistor_set_temperature",0));
@@ -392,30 +415,63 @@ static void prusa_mini_init(MachineState *machine, const mini_config_t* cfg)
 
 };
 
-
-static void prusa_mini_machine_init(MachineClass *mc)
+static void buddy_class_init(ObjectClass *oc, const void *data)
 {
-    mc->desc = "Prusa Mini 1.0+";
+    const buddyData* d = data;
+    MachineClass *mc = MACHINE_CLASS(oc);
+    mc->desc = d->descr;
     mc->family = "Prusa Mini";
-    mc->init = prusa_mini_100_init;
+    mc->init = prusa_mini_init;
     mc->default_ram_size = 0; // 0 = use default RAM from chip.
     mc->no_parallel = 1;
 	mc->no_serial = 1;
+
+    object_class_property_add_bool(oc, "has-sock", buddy_get_has_sock, buddy_set_has_sock);
+
+    buddyMachineClass *bmc = BUDDY_MACHINE_CLASS(oc);
+    bmc->cfg = d->cfg;    
 }
 
-DEFINE_MACHINE("prusa-mini", prusa_mini_machine_init)
-
-static void prusa_mini_014_machine_init(MachineClass *mc)
+static void buddy_instance_init(Object *obj)
 {
-    mc->desc = "Prusa Mini 0.1.4";
-    mc->family = "Prusa Mini";
-    mc->init = prusa_mini_014_init;
-    mc->default_ram_size = 0; // 0 = use default RAM from chip.
-    mc->no_parallel = 1;
-	mc->no_serial = 1;
+    buddyMachineState *s = BUDDY_MACHINE(obj);
+    s->has_sock = false;
 }
 
-DEFINE_MACHINE("prusa-mini-014", prusa_mini_014_machine_init)
+static const buddyData mini_data_100 = {
+    .descr = "Prusa Mini 1.0+",
+    .cfg = &mini_100_cfg
+};
+
+static const buddyData mini_data_014 = {
+    .descr = "Prusa Mini 0.1.4",
+    .cfg = &mini_014_cfg
+};
+
+static const TypeInfo buddy_machine_types[] = {
+    {
+        .name = TYPE_BUDDY_MACHINE, 
+        .parent = TYPE_MACHINE,
+        .class_size = sizeof(buddyMachineClass),
+        .instance_size = sizeof(buddyMachineState),
+        .instance_init = buddy_instance_init,
+        .abstract = true,
+    },
+    {
+        .name = MACHINE_TYPE_NAME("prusa-mini"),
+        .parent = TYPE_BUDDY_MACHINE,
+        .class_init = buddy_class_init,
+        .class_data = (void*)&mini_data_100
+    },
+    {
+        .name = MACHINE_TYPE_NAME("prusa-mini-014"),
+        .parent = TYPE_BUDDY_MACHINE,
+        .class_init = buddy_class_init,
+        .class_data = (void*)&mini_data_014    
+    }
+};
+
+DEFINE_TYPES(buddy_machine_types)
 
 // Don't enable this for tests, it breaks because it doesn't run.
 #ifndef CONFIG_GCOV

--- a/hw/arm/prusa/prusa-mini.c
+++ b/hw/arm/prusa/prusa-mini.c
@@ -309,6 +309,7 @@ static void prusa_mini_init(MachineState *machine, const mini_config_t* cfg)
     // Heaters - bed is B0/ TIM3C3, E is B1/ TIM3C4
 
     dev = qdev_new("heater");
+    object_property_add_child(OBJECT(periphs), "heater-E", OBJECT(dev));
     qdev_prop_set_uint8(dev, "thermal_mass_x10",30);
     qdev_prop_set_uint8(dev,"label", 'E');
     sysbus_realize(SYS_BUS_DEVICE(dev), &error_fatal);
@@ -324,6 +325,7 @@ static void prusa_mini_init(MachineState *machine, const mini_config_t* cfg)
 
     // Bed.
     dev = qdev_new("heater");
+    object_property_add_child(OBJECT(periphs), "heater-B", OBJECT(dev));
     qdev_prop_set_uint8(dev, "thermal_mass_x10",3);
     qdev_prop_set_uint8(dev,"label", 'B');
     sysbus_realize(SYS_BUS_DEVICE(dev), &error_fatal);

--- a/hw/arm/prusa/prusa-mk4.c
+++ b/hw/arm/prusa/prusa-mk4.c
@@ -392,6 +392,7 @@ static const mk4_cfg_t ix_027c_cfg = {
 typedef struct xBuddyMachineState {
     MachineState parent;
     bool force_mmu;
+    bool has_sock;
 } xBuddyMachineState;
 
 OBJECT_DECLARE_SIMPLE_TYPE(xBuddyMachineState, XBUDDY_MACHINE);
@@ -408,10 +409,24 @@ static void xbuddy_set_force_mmu(Object *obj, bool value, Error **errp)
     s->force_mmu = value;
 }
 
+static bool xbuddy_get_has_sock(Object *obj, Error **errp)
+{
+    xBuddyMachineState *s = XBUDDY_MACHINE(obj);
+    return s->has_sock;
+}
+
+static void xbuddy_set_has_sock(Object *obj, bool value, Error **errp)
+{
+    xBuddyMachineState *s = XBUDDY_MACHINE(obj);
+    s->has_sock = value;
+}
+
 static void mk4_init(MachineState *machine)
 {
 
 	const xBuddyMachineClass *mc = XBUDDY_MACHINE_GET_CLASS(OBJECT(machine));
+    xBuddyMachineState *s = XBUDDY_MACHINE(machine);
+
     Object* periphs = machine_get_container("peripheral");
 	const mk4_cfg_t cfg = *mc->cfg;
 
@@ -741,6 +756,8 @@ static void mk4_init(MachineState *machine)
     dev = qdev_new("heater");
     qdev_prop_set_uint8(dev, "thermal_mass_x10",cfg.e_t_mass);
     qdev_prop_set_uint8(dev,"label", 'E');
+    qdev_prop_set_bit(dev, "has_sock", s->has_sock);
+
     sysbus_realize(SYS_BUS_DEVICE(dev), &error_fatal);
     if (mc->has_modbed)
     {
@@ -956,7 +973,6 @@ static void mk4_init(MachineState *machine)
     qdev_connect_gpio_out_named(encoder, "touch",     0, t_split);
 
     // Do not create the bridge element if no kernel is suppled. Corner case for qtest.
-    xBuddyMachineState *s = XBUDDY_MACHINE(machine);
     if (kernel_len == 0 && !s->force_mmu)
     {
         // No bridge setup in this case...
@@ -1011,6 +1027,7 @@ static void xbuddy_class_init(ObjectClass *oc, const void *data)
 		mc->no_serial = 1;
 
         object_class_property_add_bool(oc, "qtest-force-mmu", xbuddy_get_force_mmu, xbuddy_set_force_mmu);
+        object_class_property_add_bool(oc, "has_sock", xbuddy_get_has_sock, xbuddy_set_has_sock);
 
 		xBuddyMachineClass* xmc = XBUDDY_MACHINE_CLASS(oc);
 		xmc->cfg = d->cfg;
@@ -1022,6 +1039,7 @@ static void xbuddy_instance_init(Object *obj)
 {
     xBuddyMachineState *s = XBUDDY_MACHINE(obj);
     s->force_mmu = false; // Set default
+    s->has_sock = false; // Set default 
 }
 
 static const xBuddyData mk4_027c = {

--- a/hw/arm/prusa/stm32_tests/meson.build
+++ b/hw/arm/prusa/stm32_tests/meson.build
@@ -6,6 +6,7 @@ qtests_buddy = [
     'prusa/stm32_tests/mini404_irsensor_test',
     'prusa/stm32_tests/mini404_hx717_test',
     'prusa/stm32_tests/mini404_hallsensor_test',
+    'prusa/stm32_tests/mini404_heater_test',
     'prusa/stm32_tests/mini404_mmu_bridge_test',
     'prusa/stm32_tests/mini404_pinda_test',
     'prusa/stm32_tests/mini404_sn74cbt_test',

--- a/hw/arm/prusa/stm32_tests/mini404_heater_test.c
+++ b/hw/arm/prusa/stm32_tests/mini404_heater_test.c
@@ -47,8 +47,7 @@ static int32_t measure_rise(QTestState *ts, int ticks)
 
 static void test_heater_sock_off(void)
 {
-    QTestState *ts = qtest_init("-machine " MACHINE
-                                " -global heater.has_sock=off");
+    QTestState *ts = qtest_init("-machine " MACHINE",has_sock=off");
     int32_t rise = measure_rise(ts, TICKS);
     /* Expect ~3840 (15.0 °C * 256). Allow a generous tolerance band to
      * absorb floating-point rounding and any first-tick scheduling jitter. */
@@ -59,8 +58,7 @@ static void test_heater_sock_off(void)
 
 static void test_heater_sock_on(void)
 {
-    QTestState *ts = qtest_init("-machine " MACHINE
-                                " -global heater.has_sock=on");
+    QTestState *ts = qtest_init("-machine " MACHINE",has_sock=on");
     int32_t rise = measure_rise(ts, TICKS);
     /* Expect ~3264 (12.75 °C * 256). */
     g_assert_cmpint(rise, >, 3000);
@@ -70,13 +68,11 @@ static void test_heater_sock_on(void)
 
 static void test_heater_sock_ratio(void)
 {
-    QTestState *ts_off = qtest_init("-machine " MACHINE
-                                    " -global heater.has_sock=off");
+    QTestState *ts_off = qtest_init("-machine " MACHINE",has_sock=off");
     int32_t r_off = measure_rise(ts_off, TICKS);
     qtest_quit(ts_off);
 
-    QTestState *ts_on = qtest_init("-machine " MACHINE
-                                   " -global heater.has_sock=on");
+    QTestState *ts_on = qtest_init("-machine " MACHINE",has_sock=on");
     int32_t r_on = measure_rise(ts_on, TICKS);
     qtest_quit(ts_on);
 

--- a/hw/arm/prusa/stm32_tests/mini404_heater_test.c
+++ b/hw/arm/prusa/stm32_tests/mini404_heater_test.c
@@ -1,0 +1,100 @@
+/*
+ * QTest test for the heater implementation, exercising the has_sock property.
+ *
+ * Copyright 2026 VintagePC <https://github.com/vintagepc>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+
+#include "qemu/osdep.h"
+#include "libqtest-single.h"
+
+#define QOM_PATH "/machine/peripheral/heater-E"
+#define TEST_PREFIX "/mini404/parts/heater/"
+#define MACHINE "prusa-mini"
+
+/* prusa-mini extruder heater uses thermal_mass_x10=30, so thermalMass=3.0
+ * with no sock and 3.0 * 0.85 = 2.55 with sock. The heater integrates
+ * currentTemp += thermalMass * (pwm/255) * 0.25 every 250 ms tick.
+ * Over 20 ticks at PWM=255:
+ *   no-sock:  +15.0 °C  -> temp_out delta = 15.0 * 256 = 3840
+ *   with-sock: +12.75 °C -> temp_out delta = 12.75 * 256 = 3264
+ */
+#define TICKS 20
+#define TICK_NS (250ULL * 1000 * 1000)
+
+static int32_t measure_rise(QTestState *ts, int ticks)
+{
+    qtest_irq_intercept_out_named(ts, QOM_PATH, "temp_out");
+    qtest_set_irq_in(ts, QOM_PATH, "raw-pwm-in", 0, 255);
+    /* First tick is scheduled at tNow+1 ms by heater_pwm_change. */
+    qtest_clock_step(ts, 1ULL * 1000 * 1000);
+    int32_t t0 = qtest_get_irq_level(ts, 0);
+    for (int i = 0; i < ticks; i++) {
+        qtest_clock_step(ts, TICK_NS);
+    }
+    int32_t tN = qtest_get_irq_level(ts, 0);
+    return tN - t0;
+}
+
+static void test_heater_sock_off(void)
+{
+    QTestState *ts = qtest_init("-machine " MACHINE
+                                " -global heater.has_sock=off");
+    int32_t rise = measure_rise(ts, TICKS);
+    /* Expect ~3840 (15.0 °C * 256). Allow a generous tolerance band to
+     * absorb floating-point rounding and any first-tick scheduling jitter. */
+    g_assert_cmpint(rise, >, 3500);
+    g_assert_cmpint(rise, <, 4200);
+    qtest_quit(ts);
+}
+
+static void test_heater_sock_on(void)
+{
+    QTestState *ts = qtest_init("-machine " MACHINE
+                                " -global heater.has_sock=on");
+    int32_t rise = measure_rise(ts, TICKS);
+    /* Expect ~3264 (12.75 °C * 256). */
+    g_assert_cmpint(rise, >, 3000);
+    g_assert_cmpint(rise, <, 3500);
+    qtest_quit(ts);
+}
+
+static void test_heater_sock_ratio(void)
+{
+    QTestState *ts_off = qtest_init("-machine " MACHINE
+                                    " -global heater.has_sock=off");
+    int32_t r_off = measure_rise(ts_off, TICKS);
+    qtest_quit(ts_off);
+
+    QTestState *ts_on = qtest_init("-machine " MACHINE
+                                   " -global heater.has_sock=on");
+    int32_t r_on = measure_rise(ts_on, TICKS);
+    qtest_quit(ts_on);
+
+    /* With-sock heatup must be strictly slower, and within ±3 % of the
+     * HEATER_SOCK_MASS_FACTOR=0.85 ratio. */
+    g_assert_cmpint(r_on, <, r_off);
+    g_assert_cmpint(r_on * 100, >, r_off * 82);
+    g_assert_cmpint(r_on * 100, <, r_off * 88);
+}
+
+int main(int argc, char **argv)
+{
+    g_test_init(&argc, &argv, NULL);
+    g_test_set_nonfatal_assertions();
+
+    qtest_add_func(TEST_PREFIX "sock-off", test_heater_sock_off);
+    qtest_add_func(TEST_PREFIX "sock-on",  test_heater_sock_on);
+    qtest_add_func(TEST_PREFIX "sock-ratio", test_heater_sock_ratio);
+
+    return g_test_run();
+}


### PR DESCRIPTION
## Summary

Adds a QOM property `heater.has_sock` (bool, default `false`) that biases the heater's thermal coefficient at realize time for nozzle-sock variants. Settable from the QEMU command line via `-global heater.has_sock=on`.

## Why

Buddy applies a per-hotend offset to the heater selftest range via `hotend_type_heater_selftest_offset()` (in `src/common/hotend_type.cpp`). On `HAS_NEXTRUDER` (MK4 / MK3.5 / MK3.9), `HotendType::stock_with_sock` returns `-20`, knocking the nozzle test range from `[195, 245]` to `[175, 225]`. Real with-sock hardware heats more slowly because the silicone sock adds thermal mass; the FW offset compensates.

The sim's heater integrator was one-size-fits-all (a fixed `e_t_mass` per machine config, no awareness of sock state). On a `config_store` EEPROM with `hotend_type=stock_with_sock`, the sim heated past the FW's adjusted upper bound and the nozzle selftest stage failed even though the heater model was nominally correct.

## v1 → v2 (per @vintagepc's review)

The first draft of this PR exposed sock state as a runtime script action `heater::SetSock(int)`. @vintagepc pointed out that sock state is a once-at-startup configuration, not something a user would dynamically toggle during printer operation, and that a QOM property applied at realize is the cleaner shape. This rewrite drops the script action entirely and replaces it with the property.

## What changed

`hw/arm/prusa/parts/heater.c`:
- New state field `sock_on` (bool).
- New helper `heater_apply_sock(s)` recomputing `s->thermalMass` from `mass10x` and `sock_on`. `HEATER_SOCK_MASS_FACTOR = 0.85f` — empirically lands the 42 s nozzle-test reading inside the FW's with-sock range `[175, 225]` for the `prusa-mk4-027c` config.
- `DEFINE_PROP_BOOL("has_sock", heater_state, sock_on, false)` in `heater_properties`.
- New `heater_realize()` callback (wired via `dc->realize`) that calls `heater_apply_sock()` once the property has been set.
- `heater_reset()` and `heater_post_load()` also call `heater_apply_sock()` so `thermalMass` stays consistent with the configured property across reset / savevm-loadvm.
- No more `ActSetSock` enum entry, no more `heater::SetSock` script registration, no more case in `heater_process_action()`.

`hw/arm/prusa/prusa-mini.c`:
- Names the two heater instances (`heater-E`, `heater-B`) via `object_property_add_child`, mirroring the existing `fan-P` / `fan-E` pattern. Makes them addressable for the new qtest.

`hw/arm/prusa/stm32_tests/mini404_heater_test.c` *(new)*:
- Three qtest cases on `prusa-mini`: drive `raw-pwm-in` at full duty, sample `temp_out` over 20 ticks of 250 ms, and verify
  - sock-off rise lands near 15 °C (`thermalMass = 3.0`, `0.75 °C/tick`),
  - sock-on rise lands near 12.75 °C (`thermalMass = 2.55`, `0.6375 °C/tick`),
  - the with-sock / no-sock ratio sits in `[0.82, 0.88]`, bracketing `HEATER_SOCK_MASS_FACTOR = 0.85`.
- Registered in `hw/arm/prusa/stm32_tests/meson.build`. Picked up by `make check-qtest-buddy` under `--enable-gcov`.

## Usage

```bash
# Default (no sock — heatup matches stock hotend_type)
qemu-system-buddy -machine prusa-mk4-027c ...

# With silicone sock — match FW config_store hotend_type=stock_with_sock
qemu-system-buddy -machine prusa-mk4-027c -global heater.has_sock=on ...
```

The harness (`sim/harness/mk4_drive.py`) consumes this via a `has_sock` constructor arg; `walk_wizard.py` plumbs it from the existing `--hotend-sock` CLI flag.

## Verification

- Build clean against the working tree.
- `-global heater.has_sock=on` accepted; `=notabool` rejected with the expected meson error (`Parameter 'has_sock' expects 'on' or 'off'`); `heater.bogus_prop=on` rejected (`Property 'heater.bogus_prop' not found`) — confirms the property is registered and typed `bool`.
- `strings qemu-system-buddy` contains `has_sock`, no `SetSock` or `"Switch heater coefficient"` action description.
- End-to-end on `prusa-mk4-027c` with a Buddy 6.6.0+14739 build walking through the selftest wizard:
  ```
  271.199s [INFO  - Selftest:10] Nozzle measure, target: 290 current: 227.118637
  ```
  That `Nozzle measure` log line only fires on `LoopResult::RunNext` (i.e. pass) at `selftest_heater.cpp:340`. Default (no sock) lands inside `[195, 245]`; with `-global heater.has_sock=on` and a `hotend_type=stock_with_sock` EEPROM the reading drops to ~206 °C and lands inside `[175, 225]`.

## Future

Multi-heater integrated machines (a hypothetical C1+INDX with some heaters socked and others not) would need a machine-level bitmask property wired through to each heater instance — exactly the `force_mmu` pattern on `prusa-mk4`. Deferred until such a machine actually exists in the codebase; all current machines have at most one socked heater per QEMU process, so `-global heater.has_sock=on` is sufficient.

## Test plan

- [x] Builds clean
- [x] `-global` property typing exercised (on/off accepted, bad values rejected, no `SetSock` symbol left)
- [x] Part-level qtest in `mini404_heater_test.c` covers both states and the ratio
- [x] End-to-end MK4 wizard selftest passes with default (`hotend_type=stock`)
- [x] End-to-end MK4 wizard selftest passes with `-global heater.has_sock=on` on a `hotend_type=stock_with_sock` EEPROM