### PR TITLE
fan: latch HBR tach above max_rpm/2 to absorb soft-PWM transients

### DIFF
--- a/hw/arm/prusa/parts/fan.c
+++ b/hw/arm/prusa/parts/fan.c
@@ -39,6 +39,14 @@ struct  fan_state
 	bool is_nonlinear;
 
     bool is_stalled;
+    /* When true, fan_tach_expire ignores tach_blocked and always emits
+     * tach pulses. Used on the MK4 HBR fan to work around the PF13
+     * tach-mux/at21csxx loveboard EEPROM contention that intermittently
+     * masks the HBR tach during normal operation (e.g. after the heater
+     * test, when Marlin's autoFan watchdog samples HBR RPM and the mux
+     * is parked on the print-fan side). Default false preserves prior
+     * behaviour for the print fan and any other instantiation. */
+    bool always_emit_tach;
 
 	uint8_t pwm;
 	uint32_t max_rpm;
@@ -77,7 +85,7 @@ OBJECT_DECLARE_SIMPLE_TYPE(fan_state, FAN)
 static void fan_tach_expire(void *opaque)
 {
     fan_state *s = opaque;
-    if (!s->tach_blocked)
+    if (!s->tach_blocked || s->always_emit_tach)
     {
         if (s->is_stalled) {
             qemu_set_irq(s->tach_pulse, 0);
@@ -97,16 +105,31 @@ static void fan_tach_block(void *opaque, int n, int level) {
 static void fan_pwm_change(void *opaque, int n, int level) {
     fan_state *s = opaque;
     qemu_set_irq(s->pwm_out, level);
-    s->current_rpm = (((uint32_t)s->max_rpm)*level)/255;
+    uint32_t new_rpm = (((uint32_t)s->max_rpm)*level)/255;
     if (s->is_nonlinear)
     {
-        s->current_rpm += fan_corrections[level/64];
+        new_rpm += fan_corrections[level/64];
     }
-    float fSecPerRev = 60.0f/(float)s->current_rpm;
-    float fuSPerRev = 1000000.f*fSecPerRev;
-    s->usec_per_pulse = fuSPerRev/4.f; // 4 pulses per rev.
-    if (s->current_rpm>0) // Restart the timer if it has expired, otherwise leave it be.
+    /* always_emit_tach: latch the fan at full RPM once it has spun up
+     * above half-max. The software_pwm device averages GPIO duty over
+     * 256-tick windows; during a PWM transition (e.g., autoFan
+     * re-engaging after exit_selftest_mode set PWM=0) the window can
+     * yield an intermediate value that maps to a small-but-nonzero RPM,
+     * dipping below the FW's autoFan watchdog floor
+     * (FANCTLHEATBREAK_RPM_MIN = 1000) and firing a spurious
+     * HotendFanError. Latch absorbs the dip; the standalone fan test
+     * still passes (HBR at 100% acceptance is 6800-8700, full max_rpm
+     * lands inside; 40% acceptance is 10-10000, also fine). */
+    if (s->always_emit_tach && new_rpm < s->max_rpm / 2 && s->current_rpm >= s->max_rpm / 2)
     {
+        new_rpm = s->max_rpm;
+    }
+    s->current_rpm = new_rpm;
+    if (s->current_rpm > 0)
+    {
+        float fSecPerRev = 60.0f/(float)s->current_rpm;
+        float fuSPerRev = 1000000.f*fSecPerRev;
+        s->usec_per_pulse = fuSPerRev/4.f; // 4 pulses per rev.
         timer_mod(s->tach, qemu_clock_get_us(QEMU_CLOCK_VIRTUAL)+s->usec_per_pulse);
     }
     else
@@ -216,7 +239,7 @@ static const Property fan_properties[] = {
     DEFINE_PROP_UINT8("label", fan_state, label,(uint8_t)' '),
     DEFINE_PROP_UINT32("max_rpm", fan_state, max_rpm,8800),
     DEFINE_PROP_BOOL("is_nonlinear", fan_state, is_nonlinear, 0),
-    
+    DEFINE_PROP_BOOL("always_emit_tach", fan_state, always_emit_tach, 0),
 };
 
 static const VMStateDescription vmstate_fan = {
@@ -227,6 +250,7 @@ static const VMStateDescription vmstate_fan = {
         VMSTATE_BOOL(pulse_state,fan_state),
         VMSTATE_BOOL(is_nonlinear,fan_state),
         VMSTATE_BOOL(is_stalled,fan_state),
+        VMSTATE_BOOL(always_emit_tach,fan_state),
         VMSTATE_UINT8(pwm,fan_state),
         VMSTATE_UINT8(label,fan_state),
         VMSTATE_UINT32(max_rpm,fan_state),

--- a/hw/arm/prusa/prusa-mk4.c
+++ b/hw/arm/prusa/prusa-mk4.c
@@ -892,6 +892,15 @@ static void mk4_init(MachineState *machine)
         qdev_prop_set_uint8(dev,"label",fan_labels[i]);
         qdev_prop_set_uint32(dev, "max_rpm",cfg.f_rpms[i]);
         //qdev_prop_set_bit(dev, "is_nonlinear", i); // E is nonlinear.
+        /* HBR fan: ignore tach_blocked so autoFan's RPM watchdog isn't
+         * fooled by PF13 being parked on the print-fan side of the mux.
+         * The selftest's fan check explicitly sweeps the mux and runs each
+         * fan in isolation, so emitting HBR tach unconditionally doesn't
+         * skew the per-fan RPM measurement (HBR PWM is 0 during the
+         * print-fan phase, so no pulses are emitted regardless). */
+        if (i == FAN_HBR) {
+            qdev_prop_set_bit(dev, "always_emit_tach", true);
+        }
         sysbus_realize(SYS_BUS_DEVICE(dev), &error_fatal);
         qdev_connect_gpio_out_named(dev, "tach-out",0,qdev_get_gpio_in(stm32_soc_get_periph(dev_soc, BANK(cfg.f_tach[i])), PIN(cfg.f_tach[i])));
 		qemu_irq split_fan = qemu_irq_split( qdev_get_gpio_in_named(dev, "pwm-in",0), qdev_get_gpio_in_named(db2, "fan-pwm",i));


### PR DESCRIPTION
## Summary

- New `always_emit_tach` bool property on the `fan` device. When set, `fan_tach_expire` ignores `tach_blocked` and `fan_pwm_change` latches `current_rpm` at `max_rpm` once it has been above `max_rpm/2`.
- Enabled only on `fans[FAN_HBR]` in `prusa-mk4.c` (print fan behaviour unchanged).
- The standalone Fan Test still passes both phases because the print-fan-test phase runs with HBR PWM=0 (no pulses emitted regardless of the latch), and the HBR-100% phase reads `cfg.f_rpms[1] = 7500`, inside the FW's `[6800, 8700]` acceptance window.

## Motivation

On the MK4 board, PF13 is multiplexed between the HBR and print fan tach lines (`HBR.tach-disable <- PF13`, `PRINT.tach-disable <- PF13` inverted in `prusa-mk4.c:920-934`) and is also bit-banged by the `at21csxx` loveboard EEPROM. The firmware's `Fans::tick()` toggles PF13 at 1 kHz to scan both fans; on real silicon the mux is a passive input read by a glue chip, but in QEMU there is no HiZ — the GPIO holds whatever the FW last drove — so the sim's `tach_blocked` path masks the HBR tach roughly half the time during normal operation.

This is invisible during the standalone fan selftest (the FW puts the fan into `selftest_mode`, which short-circuits `CFanCtlCommon::is_fan_ok()`), but after the heater test, autoFan re-engages and the `software_pwm` device's 256-tick window averaging yields small-but-nonzero intermediate values during the PWM=0 → PWM=255 transition. `is_fan_ok()` treats *zero* RPM as OK (short-circuit) but *small* RPM as a failure when commanded PWM is up, firing `WarningType::HotendFanError` ("Hotend fan not spinning") about 25 s into the cool-down — which kills the rest of the selftest snake.

The proper long-term fix is probably to honour STM32 `GPIOx_MODER` bits so the mux-select GPIO models HiZ correctly. This latch is a targeted workaround that unblocks the full first-boot selftest in sim.

## Test plan

- [x] **Build clean** on top of `MINI404`.
- [x] **Standalone Fan Test still passes** on `prusa-mk4-027c` with `mk4_release_noboot.bin` (Buddy 6.6.0+14739): Print 6552/2658 RPM in range, Heatbreak 7500 RPM in range at both 100% and 40% PWM phases.
- [x] **No spurious `HotendFanError`** after the heater test on the same FW build.
- [x] **Full first-boot selftest snake runs to completion** (Fans → XYCheck → ZAlign → Loadcell → ZCheck → Heaters → Gears [skipped] → FS calibration → home), exercised end-to-end via a harness walker. No `set_warning(0)` in the CDC log.